### PR TITLE
idmocp-32: split install-install-local-tools.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
+
+# Some test logs
+tests/.*.err
+tests/.*.report

--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ EXPERIMENTAL OpenShift operator for FreeIPA
    `$HOME/go`.)
 
 3. `operator-sdk build quay.io/username/freeipa-operator:v0.0.1`
+
+## Development tools
+
+For making life easier, a script has been included to deploy a complete
+development environment. Actually it is verified for Fedora 32, more Linux
+distributions are welcome and hoping this get more and more completed.
+
+This script try to install:
+
+- A set of needed packages for creating ansible or golang operators.
+- OpenShift Client, so that we can communicata with an OpenShift cluster.
+- Operator-SDK which make life easier creating operators.
+- (optional) Visual Studio Code.
+- (optional) CodeReady Containers.
+
+Below we see how to use the script:
+
+```shell
+./devel/install-local-tools.sh
+```

--- a/devel/include/common.inc
+++ b/devel/include/common.inc
@@ -1,0 +1,159 @@
+VERBOSE_ERROR=1
+VERBOSE_WARNING=2
+VERBOSE_INFO=3
+VERBOSE_TRACE=4
+VERBOSE_DEBUG=5
+VERBOSE_DEFAULT=$VERBOSE_WARNING
+VERBOSE=${VERBOSE:-$VERBOSE_DEFAULT}
+
+
+##
+# Just print something out to the stderr
+##
+function yield
+{
+    echo "$*" >&2
+} # yield
+
+
+##
+# Primitive to print out debug messages in stderr.
+# $@ The message to print out.
+##
+function debug-msg
+{
+    # shellcheck disable=SC2086
+    [ $VERBOSE -ge $VERBOSE_DEBUG ] && yield "DEBUG:$*"
+} # debug-msg
+
+
+##
+# Primitive to print out trace messages in stderr.
+# $@ The message to print out.
+##
+function trace-msg
+{
+    # shellcheck disable=SC2086
+    [ $VERBOSE -ge $VERBOSE_TRACE ] && yield "TRACE:$*"
+} # trace-msg
+
+
+##
+# Primitive to print out informative messages in stderr.
+# $@ The message to print out.
+##
+function info-msg
+{
+    # shellcheck disable=SC2086
+    [ $VERBOSE -ge $VERBOSE_INFO ] && yield "INFO:$*"
+} # info-msg
+
+
+##
+# Primitive to print out warning messages in stderr.
+# $@ The message to print out.
+##
+function warning-msg
+{
+    # shellcheck disable=SC2086
+    [ $VERBOSE -ge $VERBOSE_WARNING ] && yield "WARNING:$*"
+} # warning-msg
+
+
+##
+# Primitive to print out error messages in stderr.
+# $@ The message to print out.
+##
+function error-msg
+{
+    # shellcheck disable=SC2086
+    [ $VERBOSE -ge $VERBOSE_ERROR ] && yield "ERROR:$*"
+} # error-msg
+
+
+##
+# Terminate the script execution with the last return
+# code or 127 if no error code in the last operation.
+# $@ Message to be printed as error into the standard
+# error output.
+##
+function die
+{
+    local ERR=$?
+    [ $ERR -eq 0 ] && ERR=127
+    error-msg "$@"
+    exit $ERR
+} # die
+
+
+##
+# Try the operation and if it fails, finish the script
+# execution.
+##
+function try
+{
+    "$@" || die "Trying '$*'"
+} # try
+
+
+##
+# Confirmation message
+##
+function confirm
+{
+    local ans
+    ans=""
+    while [ "$ans" != "y" ] && [ "$ans" != "Y" ] && [ "$ans" != "n" ] && [ "$ans" != "N" ]
+    do
+        [ "$ans" != "" ] && echo -e "\nERROR:Please response 'y' or 'n'"
+        echo -n "$* "
+        read -r -n1 ans; printf "\n"
+    done
+    if [ "$ans" == "y" ] || [ "$ans" == "Y" ]
+    then
+        return 0
+    else
+        return 1
+    fi
+} # confirm
+
+
+##
+# Print command to be executed when VERBOSE_TRACE is set.
+##
+function verbose
+{
+    # shellcheck disable=SC2086
+    [ $VERBOSE -ge $VERBOSE_TRACE ] && yield "$*"
+    "$@"
+} # verbose
+
+
+##
+# Open the URL spicified
+# @param $1 The URL to be opened.
+##
+function open-url
+{
+    if command -v xdg-open 1>/dev/null && [ "$DISPLAY" != "" ]
+    then
+        xdg-open "$1"
+    else
+        die "Can not open '$1' URL. No xdg-open or DISPLAY found"
+    fi
+}
+
+
+##
+# Call sudo when no root user yet.
+##
+function get-root
+{
+    uid="$( id -u )"
+    if [ $uid -eq 0 ]
+    then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}

--- a/devel/install-local-tools.sh
+++ b/devel/install-local-tools.sh
@@ -1,0 +1,400 @@
+#!/bin/bash
+
+##
+# This script install development local tools to make easier the getting
+# started process for everyone.
+#
+# Usage:
+#   ./devel/install-local-tools.sh
+#
+# For debuging something wrong in the script:
+#   VERBOSE=5 ./devel/install-local-tools.sh
+##
+
+
+# shellcheck disable=SC1091
+source "./devel/include/common.inc"
+
+
+FLAG_INSTALL_VSCODE="${FLAG_INSTALL_VSCODE:-ASK}"
+FLAG_RUN_VSCODE_AFTER_INSTALL="${FLAG_RUN_VSCODE_AFTER_INSTALL:-ASK}"
+FLAG_INSTALL_CRC="${FLAG_INSTALL_CRC:-ASK}"
+
+
+OPERATOR_SDK_VERSION="v0.18.1"
+OPENSHIFT_CLIENT_ARCHIVE_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.4/openshift-client-linux.tar.gz"
+
+
+##
+# Test if the system is a Debian distribution.
+# @return Return true if it is debian else false.
+##
+function test-debian
+{
+    [ -e "/etc/debian_version" ] && return 0
+    return 1
+} # test-debian
+
+
+##
+# Test if the system is a Centos distribution.
+# @return Return true if it is Centos else false.
+##
+function test-centos
+{
+    [ -e "/etc/centos-release" ] && return 0
+    return 1
+} # test-centos
+
+
+##
+# Test if the system is a Fedora distribution.
+# @return Return true if it is Fedora else false.
+##
+function test-fedora
+{
+    [ -e "/etc/fedora-release" ] && return 0
+    return 1
+} # test-fedora
+
+
+##
+# Print the name of the linux distribution detected in the standard output.
+##
+function print-distribution
+{
+    if test-fedora; then printf "fedora\n"
+    elif test-centos; then printf "centos\n"
+    elif test-debian; then printf "debian\n"
+    else die "Can not identify the linux distribution"
+    fi
+} # print-distribution
+
+
+##
+# Print the linux distribution and the main version in the standard output.
+##
+function print-distribution-version
+{
+    local distribution
+    local version
+    distribution="$( print-distribution )"
+    version=""
+
+    case "${distribution}" in
+        "fedora" )
+            version="$( < /etc/fedora-release )"
+            version="${version##Fedora release }"
+            version="${version%% (*)*}"
+            ;;
+        "centos" )
+            version="$( < /etc/centos-release )"
+            version="${version##CentOS Linux release }"
+            version="${version%%.* (Core)*}"
+            ;;
+        "debian" )
+            version="$( < /etc/debian_version )"
+            version="${version%%.*}"
+            ;;
+        * )
+            die "'${distribution}' linux distribution unsupported"
+            ;;
+    esac
+
+    printf "%s-%s\n" "${distribution}" "${version}"
+} # print-distribution-version
+
+
+##
+# Print the package list that match the linus distribution in the standard
+# output.
+##
+function print-package-list
+{
+    local package_list_file
+    local package_list
+    package_list_file="./devel/packages/$( print-distribution-version ).txt"
+    [ -e "${package_list_file}" ] || die "'${package_list_file}' does not exist"
+    package_list="$( < "${package_list_file}" )"
+    printf "%s\n" "${package_list}"
+} # print-package-list
+
+
+##
+# Install packages for different linux distributions.
+##
+function install-packages
+{
+    local distribution
+    local package_list
+    local version
+    distribution="$( print-distribution )"
+    package_list="$( print-package-list )"
+    version="$( print-distribution-version )"
+    version="${version##*-}"
+
+    case "$distribution" in
+        "fedora" )
+            if [[ ${version} -ge 30 ]]
+            then
+                # shellcheck disable=SC2086
+                get-root dnf install -y ${package_list} \
+                || die "Installing dnf packages: '${package_list}'"
+            else
+                # shellcheck disable=SC2086
+                get-root yum install -y ${package_list} \
+                || die "Installing yum packages: '${package_list}'"
+            fi
+            ;;
+        "debian" )
+            get-root apt-get update \
+            || die "Updating debian packages"
+            # shellcheck disable=SC2086
+            get-root apt-get install -y ${package_list} \
+            || die "Installing debian packages"
+            ;;
+        "centos" )
+            if [[ ${version} -ge 8 ]]
+            then
+                # shellcheck disable=SC2086
+                get-root dnf install -y ${package_list}
+            else
+                # shellcheck disable=SC2086
+                get-root yum install -y ${package_list}
+            fi
+            ;;
+        * )
+            die "Fedora version '$FEDORA_VERSION' is not supported"
+    esac
+} # install-packages
+
+
+##
+# Install golang tools
+##
+function install-go-tools
+{
+    [ "$GOPATH" == "" ] && {
+        GOPATH="$HOME/go"
+        [ -e "$GOPATH" ] || mkdir -p "$GOPATH"
+        export PATH="$GOPATH/bin:$PATH"
+    }
+
+    # Install godoc
+    verbose go install -v golang.org/x/tools/cmd/godoc
+
+    # Install debugger
+    verbose go install -v github.com/go-delve/delve/cmd/dlv
+
+    # Install linter
+    verbose go install -v golang.org/x/lint/golint
+
+} # install-go-tools
+
+
+##
+# Install Visual Studio Code.
+##
+function install-vscode
+{
+    local distribution
+    local package_list
+    local version
+    distribution="$( print-distribution )"
+    version="$( print-distribution-version )"
+    version="${version##*-}"
+
+    case "$distribution" in
+        "fedora" )
+            get-root rpm --import "https://packages.microsoft.com/keys/microsoft.asc"
+            cat <<EOF | get-root tee /etc/yum.repos.d/vscode.repo 1>/dev/null
+[code]
+name=Visual Studio Code
+baseurl=https://packages.microsoft.com/yumrepos/vscode
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+EOF
+            if [[ ${version} -ge 30 ]]
+            then
+                get-root dnf check-update
+                get-root dnf install -y code \
+                || die "Installing dnf packages: 'code'"
+            else
+                get-root yum update
+                get-root yum install -y code \
+                || die "Installing yum packages: 'code'"
+            fi
+            ;;
+        "debian" )
+            # https://linuxhint.com/install_visual_studio_code_debian_10/
+            if [[ ${version} -ge 10 ]]
+            then
+                curl -L -o /tmp/code.deb "https://go.microsoft.com/fwlink/?LinkID=760868" \
+                || die "Downloading VSCode package"
+                get-root apt update \
+                || die "Updating debian packages"
+                get-root apt install -y /tmp/code.deb \
+                || die "Installing VSCode package"
+            else
+                die "Visual Studio Code is supported starting at Debian 10 (Buster)"
+            fi
+            ;;
+        "centos" )
+            get-root rpm --import "https://packages.microsoft.com/keys/microsoft.asc"
+            cat <<EOF | get-root tee /etc/yum.repos.d/vscode.repo 1>/dev/null
+[code]
+name=Visual Studio Code
+baseurl=https://packages.microsoft.com/yumrepos/vscode
+enabled=1
+gpgcheck=1
+gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+EOF
+            if [[ ${version} -ge 8 ]]
+            then
+                get-root dnf check-update
+                get-root dnf install -y code \
+                || die "Installing dnf packages: 'code'"
+            else
+                die "Starting support at Centos 8"
+            fi
+            ;;
+        * )
+            die "Fedora version '$version' is not supported"
+            ;;
+    esac
+} # install-vscode
+
+
+BIN_FILE="$0"
+[ "$( dirname "${BIN_FILE}" )" == "./devel" ] || die "Run this script from the repository base path as: ./devel/install-local-tools.sh"
+
+
+# Install packages
+echo ">> Installing packages"
+verbose install-packages
+
+# Install golang tools
+echo ">> Installing golang tools"
+verbose install-go-tools
+
+# Install OpenShift Client
+command -v oc 2>/dev/null 1>/dev/null || {
+    echo ">> Installing OpenShift Client"
+    TMP_FILE="/tmp/openshift-client.tar.gz"
+    [ ! -e "${TMP_FILE}" ] || rm -f "${TMP_FILE}" || die "Removing '${TMP_FILE}'"
+    verbose curl -o "${TMP_FILE}" --silent -L "$OPENSHIFT_CLIENT_ARCHIVE_URL" \
+    && verbose get-root tar xzf "${TMP_FILE}" -C /usr/local/bin/ \
+    && oc completion bash | get-root tee /usr/share/bash-completion/completions/oc 1>/dev/null \
+    && rm -f "${TMP_FILE}"
+} || die "Installing OpenShift Client"
+
+
+# Install operator-sdk
+command -v operator-sdk 2>/dev/null 1>/dev/null || {
+    echo ">> Installing Operator-SDK ${OPERATOR_SDK_VERSION}"
+    ( verbose curl -L --silent -o "operator-sdk" "https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-$( uname -m )-linux-gnu" \
+      && verbose chmod a+x operator-sdk \
+      && verbose get-root mv operator-sdk /usr/local/bin/operator-sdk \
+      && operator-sdk completion bash \
+         | get-root tee /usr/share/bash-completion/completions/operator-sdk 1>/dev/null 
+    ) || die "Installing Operator-SDK ${OPERATOR_SDK_VERSION}"
+}
+
+
+# Install Visual Studio Code (optional)
+command -v code 2>/dev/null 1>/dev/null || {
+    echo "Visual Studio Code is an IDE which could provide a complete solution for"
+    echo "working with the different technologies used with operator-sdk"
+
+    if [ "$FLAG_INSTALL_VSCODE" == "YES" ] \
+       || ( [ "$FLAG_INSTALL_VSCODE" == "ASK" ] \
+            && confirm "Do you want to install Visual Studio Code?"
+          )
+    then
+        echo ">> Installing repository for 'code' package"
+        install-vscode
+        echo "Recommended plug-ins"
+        echo "- Go"
+        echo "- Ansible"
+        echo "- YAML"
+        echo "- OpenShift Extension Pack"
+        echo "- Knative"
+        echo "- Docker"
+    fi
+
+    command -v code 2>/dev/null 1>/dev/null \
+    && echo ">> Visual Studio Code is installed" \
+    &&  if [ "$FLAG_RUN_VSCODE_AFTER_INSTALL" == "YES" ] \
+           || ( [ "$FLAG_RUN_VSCODE_AFTER_INSTALL" == "ASK" ] \
+                && confirm "Do you want to open Visual Studio Code now?"
+              )
+        then
+            code
+        fi
+}
+
+
+# Install CodeReady Containers
+command -v crc 2>/dev/null 1>/dev/null || {
+    if  [ "$FLAG_INSTALL_CRC" == "YES" ] \
+        || ( [ "$FLAG_INSTALL_CRC" == "ASK" ] \
+             && confirm "Do you want to install CodeReady Container?"
+           )
+    then
+        echo ">> Installing CodeReadyContainer"
+        [ ! -e pull-secret ] && [ ! -e "$( xdg-user-dir DOWNLOAD )/pull-secret" ] && {
+            echo "WARNING:File '$PWD/pull-secret' does not exist"
+            echo ">> Please download 'pull-secret' file in your Download file"
+            echo "Opening browser for getting it at: https://cloud.redhat.com/openshift/install/crc/installer-provisioned"
+            open-url "https://cloud.redhat.com/openshift/install/crc/installer-provisioned"
+        }
+        if [ ! -e pull-secret ] && [ -e "$( xdg-user-dir DOWNLOAD )/pull-secret" ]
+        then
+            mv "$( xdg-user-dir DOWNLOAD )/pull-secret" "$PWD/pull-secret"
+        fi
+        # [ ! -e pull-secret ] && die "Can not find 'pull-secret' file"
+
+        [ ! -e crc-linux-amd64.tar.xz ] && [ ! -e "$( xdg-user-dir DOWNLOAD )/crc-linux-amd64.tar.xz" ] && {
+            echo "ERROR:File '${PWD}/crc-linux-amd64.tar.xz' does not exist"
+            echo "Opening browser for getting it at: https://cloud.redhat.com/openshift/install/crc/installer-provisioned"
+            echo "Please download the linux version and copy it to '${PWD}' directory."
+            open-url "https://cloud.redhat.com/openshift/install/crc/installer-provisioned"
+            echo "INFO: Rerun 'install-local-tools' when the file has been downloaded"
+            exit 1
+        }
+        [ -e crc-linux-amd64.tar.xz ] \
+        || mv "$( xdg-user-dir DOWNLOAD )/crc-linux-amd64.tar.xz" "crc-linux-amd64.tar.xz"
+
+        # Extracting crc binary
+        [ ! -e crc-linux ] || rm -rf crc-linux
+        mkdir crc-linux
+        try tar xf crc-linux-amd64.tar.xz -C ./crc-linux --strip-components 1 \
+        && ( [ -e "${HOME}/.local/bin" ] || mkdir -p "${HOME}/.local/bin" ) \
+        && cp -f crc-linux/crc "${HOME}/.local/bin/crc" \
+        && rm -rf crc-linux
+
+        echo ">> Deploying VM with OpenShift"
+        verbose crc setup || die "Setting up CodeReady Containers"
+
+        cat <<EOF
+>> Local CodeReadyContainer cluster
+To create the local cluster run 'crc start --pull-secret-file $PWD/pull-secret'
+Run 'crc console --credentials' if you forget them.
+EOF
+    fi
+}
+
+unset GOPATH
+
+# shellcheck disable=SC1090
+source "$HOME/.bashrc"
+[ "$GOPATH" == "" ] && {
+    cat <<EOF
+Append the below at the end of your .bashrc file:
+# Golang support
+export GOPATH="$HOME/go"
+export PATH="$GOPATH/bin:$PATH"
+EOF
+}
+

--- a/devel/packages/centos-8.txt
+++ b/devel/packages/centos-8.txt
@@ -1,0 +1,13 @@
+golang
+git
+gcc
+centos-release-ansible-29
+gettext
+less
+openssh-clients
+which
+podman
+buildah
+xdg-utils
+xdg-user-dirs
+curl

--- a/devel/packages/debian-10.txt
+++ b/devel/packages/debian-10.txt
@@ -1,0 +1,12 @@
+golang
+git
+gcc
+ansible
+gettext
+less
+openssh-client
+docker
+xdg-utils
+xdg-user-dirs
+curl
+debianutils

--- a/devel/packages/debian-9.txt
+++ b/devel/packages/debian-9.txt
@@ -1,0 +1,12 @@
+golang
+git
+gcc
+ansible
+gettext
+less
+openssh-client
+docker
+xdg-utils
+xdg-user-dirs
+curl
+debianutils

--- a/devel/packages/fedora-30.txt
+++ b/devel/packages/fedora-30.txt
@@ -1,0 +1,13 @@
+golang
+git
+gcc
+ansible
+gettext
+less
+openssh-clients
+which
+podman
+buildah
+xdg-utils
+xdg-user-dirs
+curl

--- a/devel/packages/fedora-31.txt
+++ b/devel/packages/fedora-31.txt
@@ -1,0 +1,13 @@
+golang
+git
+gcc
+ansible
+gettext
+less
+openssh-clients
+which
+podman
+buildah
+xdg-utils
+xdg-user-dirs
+curl

--- a/devel/packages/fedora-32.txt
+++ b/devel/packages/fedora-32.txt
@@ -1,0 +1,13 @@
+golang
+git
+gcc
+ansible
+gettext
+less
+openssh-clients
+which
+podman
+buildah
+xdg-utils
+xdg-user-dirs
+curl

--- a/tests/test-install-local-tools.sh
+++ b/tests/test-install-local-tools.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+
+DEFAULT_TIMEOUT=1200   # 20 minutes
+
+declare -a MATRIX_FLAGS
+
+MATRIX_FLAGS[1]="NO NO NO"
+MATRIX_FLAGS[2]="YES NO NO"
+MATRIX_FLAGS[3]="ASK NO NO"
+MATRIX_FLAGS[4]="ASK NO NO"
+
+MATRIX_FLAGS[5]="NO YES NO"
+MATRIX_FLAGS[6]="YES YES NO" #
+MATRIX_FLAGS[7]="ASK YES NO"
+MATRIX_FLAGS[8]="ASK YES NO" #
+
+MATRIX_FLAGS[9]="NO ASK NO"
+MATRIX_FLAGS[10]="YES ASK NO"
+MATRIX_FLAGS[11]="ASK ASK NO"
+MATRIX_FLAGS[12]="ASK ASK NO"
+MATRIX_FLAGS[13]="NO ASK NO"
+MATRIX_FLAGS[14]="YES ASK NO"
+MATRIX_FLAGS[15]="ASK ASK NO" #
+MATRIX_FLAGS[16]="ASK ASK NO" #
+
+MATRIX_FLAGS[17]="NO ASK YES"
+MATRIX_FLAGS[18]="YES ASK YES"
+MATRIX_FLAGS[19]="ASK ASK YES"
+MATRIX_FLAGS[20]="ASK ASK YES"
+MATRIX_FLAGS[21]="NO ASK YES"   #
+MATRIX_FLAGS[22]="YES ASK YES"  #
+MATRIX_FLAGS[23]="ASK ASK YES"  #
+MATRIX_FLAGS[24]="ASK ASK YES"  #
+
+MATRIX_FLAGS[25]="NO ASK ASK"
+MATRIX_FLAGS[26]="YES ASK ASK"
+MATRIX_FLAGS[27]="ASK ASK ASK"
+MATRIX_FLAGS[28]="ASK ASK ASK"
+MATRIX_FLAGS[29]="NO ASK ASK"
+MATRIX_FLAGS[30]="YES ASK ASK"
+MATRIX_FLAGS[31]="ASK ASK ASK"
+MATRIX_FLAGS[32]="ASK ASK ASK"
+MATRIX_FLAGS[33]="NO ASK ASK"
+MATRIX_FLAGS[34]="YES ASK ASK"
+MATRIX_FLAGS[35]="ASK ASK ASK"
+MATRIX_FLAGS[36]="ASK ASK ASK"
+MATRIX_FLAGS[37]="NO ASK ASK"
+MATRIX_FLAGS[38]="YES ASK ASK"
+MATRIX_FLAGS[39]="ASK ASK ASK"
+MATRIX_FLAGS[40]="ASK ASK ASK"
+
+MATRIX_FLAGS[41]="YES NO NO"
+
+
+declare -a MATRIX_INPUTS
+
+MATRIX_INPUTS[1]=""
+MATRIX_INPUTS[2]=""
+MATRIX_INPUTS[3]="n"
+MATRIX_INPUTS[4]="y"
+
+MATRIX_INPUTS[5]=""
+MATRIX_INPUTS[6]="" #
+MATRIX_INPUTS[7]="n"
+MATRIX_INPUTS[8]="y" #
+
+MATRIX_INPUTS[9]="n"
+MATRIX_INPUTS[10]="n"
+MATRIX_INPUTS[11]="n"
+MATRIX_INPUTS[12]="yn"
+MATRIX_INPUTS[13]=""
+MATRIX_INPUTS[14]="n"
+MATRIX_INPUTS[15]="n"  #
+MATRIX_INPUTS[16]="yn" #
+
+MATRIX_INPUTS[17]=""
+MATRIX_INPUTS[18]="n"
+MATRIX_INPUTS[19]="n"
+MATRIX_INPUTS[20]="yn"
+MATRIX_INPUTS[21]=""    #
+MATRIX_INPUTS[22]="y"   #
+MATRIX_INPUTS[23]="n"   #
+MATRIX_INPUTS[24]="yn"  #
+
+MATRIX_INPUTS[25]="n"
+MATRIX_INPUTS[26]="n"
+MATRIX_INPUTS[27]="nn"
+MATRIX_INPUTS[28]="ynn"
+MATRIX_INPUTS[29]="n"
+MATRIX_INPUTS[30]="nn"
+MATRIX_INPUTS[31]="nn"
+MATRIX_INPUTS[32]="yny"
+MATRIX_INPUTS[33]="y"
+MATRIX_INPUTS[34]="ny"
+MATRIX_INPUTS[35]="ny"
+MATRIX_INPUTS[36]="yny"
+MATRIX_INPUTS[37]="y"
+MATRIX_INPUTS[38]="ny"
+MATRIX_INPUTS[39]="ny"
+MATRIX_INPUTS[40]="yny"
+
+MATRIX_INPUTS[41]=""
+
+
+declare -a MATRIX_EXPECTED
+
+MATRIX_EXPECTED[1]=0
+MATRIX_EXPECTED[2]=0
+MATRIX_EXPECTED[3]=0
+MATRIX_EXPECTED[4]=0
+
+MATRIX_EXPECTED[5]=0
+MATRIX_EXPECTED[6]=0
+MATRIX_EXPECTED[7]=0
+MATRIX_EXPECTED[8]=0
+
+MATRIX_EXPECTED[9]=0
+MATRIX_EXPECTED[10]=0
+MATRIX_EXPECTED[11]=0
+MATRIX_EXPECTED[12]=0
+MATRIX_EXPECTED[13]=0
+MATRIX_EXPECTED[14]=0
+MATRIX_EXPECTED[15]=0
+MATRIX_EXPECTED[16]=0
+
+MATRIX_EXPECTED[17]=0
+MATRIX_EXPECTED[18]=0
+MATRIX_EXPECTED[19]=0
+MATRIX_EXPECTED[20]=0
+MATRIX_EXPECTED[21]=0
+MATRIX_EXPECTED[22]=0
+MATRIX_EXPECTED[23]=0
+MATRIX_EXPECTED[24]=0
+
+MATRIX_EXPECTED[25]=0
+MATRIX_EXPECTED[26]=0
+MATRIX_EXPECTED[27]=0
+MATRIX_EXPECTED[28]=0
+MATRIX_EXPECTED[29]=0
+MATRIX_EXPECTED[30]=0
+MATRIX_EXPECTED[31]=0
+MATRIX_EXPECTED[32]=0
+MATRIX_EXPECTED[32]=0
+MATRIX_EXPECTED[34]=0
+MATRIX_EXPECTED[35]=0
+MATRIX_EXPECTED[36]=0
+MATRIX_EXPECTED[37]=0
+MATRIX_EXPECTED[38]=0
+MATRIX_EXPECTED[39]=0
+MATRIX_EXPECTED[40]=0
+
+MATRIX_EXPECTED[41]=0
+
+
+declare -a CONTAINER_IMAGES
+
+# shellcheck disable=SC2153
+if [ "${CONTAINER_IMAGE}" == "" ]
+then
+    CONTAINER_IMAGES=("centos:8" \
+                      "fedora:30" \
+                      "fedora:31" \
+                      "fedora:32" \
+                      "debian:10" \
+                     )
+else
+    CONTAINER_IMAGES=("${CONTAINER_IMAGE}")
+fi
+
+
+declare -a RESULT_MATRIX
+for index in "${!MATRIX_FLAGS[@]}"; do RESULT_MATRIX[$index]=0; done
+
+
+##
+# Print out the command to be executed, and execute it.
+##
+function verbose
+{
+    echo "$@" >&2
+    "$@"
+} # verbose
+
+
+##
+# Run a test iteration with the environment variables
+# specified.
+##
+function run-test
+{
+    local delay
+    local container_id
+    local pid_logs
+    local reto
+
+
+    function exist-container
+    {
+        [ "$container_id" == "" ] && return 1
+        $oci container exec "${container_id}" true &>/dev/null || return 2
+        return 0
+    }
+
+    function kill-container
+    {
+        echo "Killing container ${container_id}"
+        exist-container && {
+            $oci container kill "${container_id}" 1>/dev/null
+            sleep 1
+        }
+        exist-container && {
+            $oci container kill --signal KILL "${container_id}" &>/dev/null
+            sleep 1
+        }
+    }
+
+    reto=0
+    delay="$1"
+    shift 1
+    deadline=$( date +%s )
+    deadline=$(( deadline + delay ))
+    [ "$delay" == "" ] && echo "ERROR:No timeout specified" >&2 && exit 1
+
+    container_id="$( STDIN_STREAM="${MATRIX_INPUTS[$index]}" \
+    ${oci} run  -d \
+                --volume "$PWD:$PWD:z" \
+                --workdir "$PWD" \
+                -e FLAG_INSTALL_VSCODE="${FLAG_INSTALL_VSCODE}" \
+                -e FLAG_RUN_VSCODE_AFTER_INSTALL="${FLAG_RUN_VSCODE_AFTER_INSTALL}" \
+                -e FLAG_INSTALL_CRC="${FLAG_INSTALL_CRC}" \
+                fedora:32 \
+                /bin/bash -c "./devel/install-local-tools.sh"
+    )"
+    $oci container logs --follow "${container_id}" &
+    pid_logs="$!"
+    trap 'kill-container' SIGINT
+    while [ "$( date +%s )" -lt "$deadline" ]
+    do
+        $oci container exec "${container_id}" true 2>/dev/null || break
+        sleep 3
+    done
+    if [ "$( date +%s )" -ge "$deadline" ]
+    then
+        # Timeout
+        kill ${pid_logs}
+        wait ${pid_logs}
+        kill-container
+        return 127
+    fi
+    reto="$( $oci container wait "${container_id}" 2>/dev/null )"
+    $oci container rm -f "${container_id}" &>/dev/null
+    return $reto
+}
+
+
+START_INDEX=${START_INDEX:-1}
+END_INDEX=${END_INDEX:-40}
+
+if command -v podman 1>/dev/null 2>/dev/null
+then
+    oci="podman"
+elif command -v docker 1>/dev/null 2>/dev/null
+then
+    oci="docker"
+else
+    echo "ERROR:podman nor docker were found"
+    exit 3
+fi
+
+
+###############################################################################
+
+# Now launch the tests for all the different scenarios
+
+###############################################################################
+
+true > ".test-install-local-tools.report"
+for image in "${CONTAINER_IMAGES[@]}"
+do
+    for index in "${!MATRIX_FLAGS[@]}"
+    do
+        [ $index -lt $START_INDEX ] && continue
+        [ $index -gt $END_INDEX ] && continue
+        # shellcheck disable=SC2206
+        CURRENT_FLAGS=(${MATRIX_FLAGS[$index]})
+        echo "INFO:image='${image}'; CURRENT_FLAGS[$index]=${CURRENT_FLAGS[*]}; MATRIX_EXPECTED=${MATRIX_EXPECTED[$index]}; MATRIX_INPUTS[$index]=${MATRIX_INPUTS[$index]}" >&2
+        FLAG_INSTALL_VSCODE="${CURRENT_FLAGS[0]}"
+        FLAG_RUN_VSCODE_AFTER_INSTALL="${CURRENT_FLAGS[1]}"
+        FLAG_INSTALL_CRC="${CURRENT_FLAGS[2]}"
+        run-test "${DEFAULT_TIMEOUT}"
+        RESULT_MATRIX[$index]=$?
+        echo "INFO:RESULT=${RESULT_MATRIX[$index]}" >&2
+    done
+
+    # Print result report
+    for index in "${!MATRIX_FLAGS[@]}"
+    do
+        [ $index -lt $START_INDEX ] && continue
+        [ $index -gt $END_INDEX ] && continue
+        if [ ${RESULT_MATRIX[$index]} -eq ${MATRIX_EXPECTED[$index]} ]
+        then
+            RESULT="SUCCESS"
+        else
+            RESULT="FAILURE; RESULT=${RESULT_MATRIX[$index]}; EXPECTED=${MATRIX_EXPECTED[$index]}"
+        fi
+        echo "image='${image}'; index=$index; CURRENT_FLAGS[$index]=${CURRENT_FLAGS[*]}; MATRIX_EXPECTED=${MATRIX_EXPECTED[$index]}: ${RESULT}" >>tests/.test-install-local-tools.report
+    done
+done


### PR DESCRIPTION
This pull request provide a simple way to prepare the workstation for developing golang operators quickly.

Install the development tools for developing operators. A few changes from the initial version proposed in freeipa-operator:
- golang is installed from RPM repos, but their tools are installed/updated from repositories; Always the tools will be updated.
- Better container managing in the test script.
- godoc, golint, and debugger are installed from source repositories.
----
As the initial script, it provides:
- Install needed packages.
- Install golang tools.
- Install OpenShift client.
- Install Operator-sdk.
- Install Visual Studio Code (optional).
- Install CodeReady Containers (optional).
----
I am launching the test from my workstation by:

```shell
START_INDEX=41 END_INDEX=41 CONTAINER_IMAGE=fedora:32 ./tests/test-install-local-tools.sh
```
----
Usage of the script. It only have to be launched the below:

```shell
./devel/install-local-tools.sh
```

