### PR TITLE
Append git local hooks; install it with install-local-tools; fix lint.sh and fix linter hints; Update pipeline to use lint.sh

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,53 +17,25 @@ jobs:
     # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps
     steps:
       - uses: actions/checkout@v2
-      # - name: Lint README.md file
-      #   uses: avto-dev/markdown-lint@v1
-      #   with:
-      #     rules: '/lint/rules/changelog.js'
-      #     config: '/lint/config/changelog.yml'
-      #     args: './README.md'
 
-      # Lint Dockerfile files
-      - name: Lint Dockerfile
-        uses: ./.github/actions/hadolint
-        with:
-          file: ./build/Dockerfile
-
-      # Lint Shell Scripts
-      - name: Lint entrypoint
-        uses: ./.github/actions/shellcheck
-        with:
-          file: build/bin/entrypoint
-      - name: Lint user_setup
-        uses: ./.github/actions/shellcheck
-        with:
-          file: build/bin/user_setup
-
-      # Lint YAML files
-      - name: Lint .github/workflows/main.yml Workflow file
-        uses: ./.github/actions/yamllint
-        with:
-          file: .github/workflows/main.yml
-      - name: Lint deploy/operator.yaml
-        uses: ./.github/actions/yamllint
-        with:
-          file: deploy/operator.yaml
-      - name: Lint deploy/role.yaml
-        uses: ./.github/actions/yamllint
-        with:
-          file: deploy/role.yaml
-      - name: Lint deploy/role_binding.yaml
-        uses: ./.github/actions/yamllint
-        with:
-          file: deploy/role_binding.yaml
-      - name: Lint deploy/service_account.yaml
-        uses: ./.github/actions/yamllint
-        with:
-          file: deploy/service_account.yaml
-
-      # Lint Markdown files
-      - name: Lint README.md file
-        uses: ./.github/actions/lint-markdown
-        with:
-          file: README.md
+      - name: Lint Shell Script files
+        run: ./devel/lint.sh  $( find . -name '*.sh' )
+      - name: Lint Markdown files
+        run: ./devel/lint.sh  $( find . -name '*.md' )
+      - name: Lint YAML files
+        run: ./devel/lint.sh  $( find . -name '*.yml' -o -name '*.yaml' )
+      - name: Lint Dockerfile files
+        run: |
+          ./devel/lint.sh  $( find . -name 'Dockerfile' \
+          -o -name 'Dockerfile.*' )
+      - name: Lint go files
+        run: |
+          [ -e "$HOME/go" ] || mkdir -p "$HOME/go"
+          GOPATH="$HOME/go" \
+          FLAG_INSTALL_VSCODE=NO \
+          FLAG_RUN_VSCODE_AFTER_INSTALL=NO \
+          FLAG_INSTALL_CRC=NO \
+          ./devel/install-local-tools.sh
+          GOPATH="$HOME/go" \
+          PATH="$GOPATH/bin:$PATH" \
+          ./devel/lint.sh  $( find . -name '*.go' )

--- a/devel/install-local-tools.sh
+++ b/devel/install-local-tools.sh
@@ -63,9 +63,9 @@ function test-fedora
 ##
 function print-distribution
 {
-    if test-fedora; then printf "fedora\n"
-    elif test-centos; then printf "centos\n"
-    elif test-debian; then printf "debian\n"
+    if test-fedora; then printf "fedora\\n"
+    elif test-centos; then printf "centos\\n"
+    elif test-debian; then printf "debian\\n"
     else die "Can not identify the linux distribution"
     fi
 } # print-distribution
@@ -95,13 +95,14 @@ function print-distribution-version
         "debian" )
             version="$( < /etc/debian_version )"
             version="${version%%.*}"
+            version="${version%%/*}"  # Ubuntu 18.04 return "buster/sid"
             ;;
         * )
             die "'${distribution}' linux distribution unsupported"
             ;;
     esac
 
-    printf "%s-%s\n" "${distribution}" "${version}"
+    printf "%s-%s\\n" "${distribution}" "${version}"
 } # print-distribution-version
 
 
@@ -116,7 +117,7 @@ function print-package-list
     package_list_file="./devel/packages/$( print-distribution-version ).txt"
     [ -e "${package_list_file}" ] || die "'${package_list_file}' does not exist"
     package_list="$( < "${package_list_file}" )"
-    printf "%s\n" "${package_list}"
+    printf "%s\\n" "${package_list}"
 } # print-package-list
 
 
@@ -181,13 +182,13 @@ function install-go-tools
     }
 
     # Install godoc
-    verbose go install -v golang.org/x/tools/cmd/godoc
+    verbose go get -u -v golang.org/x/tools/cmd/godoc
 
     # Install debugger
-    verbose go install -v github.com/go-delve/delve/cmd/dlv
+    verbose go get -u -v github.com/go-delve/delve/cmd/dlv
 
     # Install linter
-    verbose go install -v golang.org/x/lint/golint
+    verbose go get -u -v golang.org/x/lint/golint
 
 } # install-go-tools
 
@@ -297,7 +298,7 @@ command -v operator-sdk 2>/dev/null 1>/dev/null || {
       && verbose chmod a+x operator-sdk \
       && verbose get-root mv operator-sdk /usr/local/bin/operator-sdk \
       && operator-sdk completion bash \
-         | get-root tee /usr/share/bash-completion/completions/operator-sdk 1>/dev/null 
+         | get-root tee /usr/share/bash-completion/completions/operator-sdk 1>/dev/null
     ) || die "Installing Operator-SDK ${OPERATOR_SDK_VERSION}"
 }
 
@@ -384,6 +385,13 @@ Run 'crc console --credentials' if you forget them.
 EOF
     fi
 }
+
+
+[ ! -e .git/hooks/pre-commit ] && {
+    echo ">> Installing git-hooks"
+    cp -f ./devel/pre-commit.sh .git/hooks/pre-commit
+}
+
 
 unset GOPATH
 

--- a/devel/lint.sh
+++ b/devel/lint.sh
@@ -4,7 +4,7 @@
 # Helper script for linting files in the repository.
 ##
 
-# shellcheck source=./devel/include/verbose.inc
+# shellcheck disable=SC1091
 source "./devel/include/verbose.inc"
 
 
@@ -23,109 +23,169 @@ GO_FILES=()
 declare -a MARKDOWN_FILES
 MARKDOWN_FILES=()
 
+declare -a UNKNOWN_FILES
+UNKNOWN_FILES=()
+
 FORCE=""
 
-
-
+if command -v podman &>/dev/null; then
+    oci="podman"
+elif command -v docker &>/dev/null; then
+    oci="docker"
+else
+    die "Container runtime not found"
+fi
 
 ##
 # Lint shellscripts
 ##
 function lint-shellscript
 {
-    local filepath
-    filepath="$1"
-    shift 1
-    podman run --rm -it \
-               --volume "$PWD:/data:z" \
-               --workdir "/data" \
-               --entrypoint shellcheck \
-               docker.io/nlknguyen/alpine-shellcheck:latest \
-               -x "${filepath}"
+    [ $# -eq 0 ] && return 0
+    $oci run --rm -it \
+             --volume "$PWD:/data:z" \
+             --workdir "/data" \
+             --entrypoint shellcheck \
+             docker.io/nlknguyen/alpine-shellcheck:latest \
+             -x "$@"
 }
 
 
 ##
-# Lint a Dockerfile file
+# Lint a Dockerfile files
 ##
 function lint-dockerfile
 {
-    local filepath
-    filepath="$1"
-    shift 1
-    podman run --rm -it \
-               --volume "$PWD:/data:z" \
-               --workdir "/data" \
-               --entrypoint /bin/hadolint \
-               hadolint/hadolint:latest \
-               "${filepath}"
+    [ $# -eq 0 ] && return 0
+    $oci run --rm -it \
+             --volume "$PWD:/data:z" \
+             --workdir "/data" \
+             --entrypoint /bin/hadolint \
+             hadolint/hadolint:latest \
+             "$@" \
+    || return 1
+    return 0
 }
 
 
 ##
-# Lint a YAML file
+# Lint a YAML files
 ##
 function lint-yaml
 {
-    local filepath
-    filepath="$1"
-    shift 1
-    podman run --rm -it \
+    [ $# -eq 0 ] && return 0
+    $oci   run --rm -it \
                --volume "$PWD:/data:z" \
                --workdir "/data" \
                --entrypoint yamllint \
                docker.io/cytopia/yamllint:latest \
-               "${filepath}"
+               "$@" \
+    || return 1
+    return 0
 }
 
 
 ##
-# Lint a GO file or directory
+# Lint GO files
 ##
 function lint-go
 {
-    local filepath
-    filepath="$1"
-    shift 1
-    podman run --rm -it \
-               --volume "$PWD:/data:z" \
-               --workdir "/data" \
-               --entrypoint golint \
-               docker.io/cytopia/golint:latest \
-               "${filepath}"
+    local reto
+    [ $# -eq 0 ] && return 0
+    [ "$GOPATH" == "" ] && die "GOPATH is not defined or empty"
+    reto=0
+    for file in "${@}"
+    do
+        $oci   run --rm -it \
+                   -e "GOPATH=/go" \
+                   --volume "$GOPATH:/go:z" \
+                   --volume "$PWD:/data:z" \
+                   --workdir "/data" \
+                   --entrypoint golint \
+                   docker.io/cytopia/golint:latest \
+                   "${file}" \
+        || reto=1
+    done
+    return $reto
 }
 
 
 ##
-# Lint a Markdown docoument
+# Lint a Markdown docouments
 ##
 function lint-markdown
 {
-    local filepath
-    filepath="$1"
-    shift 1
-    podman run --rm -it \
-               --volume "$PWD:/data:z" \
-               --workdir "/data" \
-               docker.io/markdownlint/markdownlint \
-               "${filepath}"
+    local reto
+    [ $# -eq 0 ] && return 0
+    reto=0
+    for file in "$@"
+    do
+        $oci   run --rm -it \
+                   --volume "$PWD:/data:z" \
+                   --workdir "/data" \
+                   docker.io/markdownlint/markdownlint \
+                   "${file}" \
+        || reto=1
+    done
+    return $reto
 }
 
 
 ##
-# Lint a Kubernete object.
+# Lint a Kubernete objects
 ##
 function lint-kubeobject
 {
-    local filepath
-    filepath="$1"
-    shift 1
-    podman run --rm -it \
+    [ $# -eq 0 ] && return 0
+    $oci   run --rm -it \
                --volume "$PWD:/data:z" \
                --workdir "/data" \
                --entrypoint /bin/bash \
                docker.io/openshift/origin-cli:v4.0 \
-               -c "oc login -u '${OC_USERNAME}' -p '${OC_PASSWORD}' --insecure-skip-tls-verify=true '${OC_API}' && oc apply --dry-run --validate -f '${filepath}'"
+               -c "oc login -u '${OC_USERNAME}' -p '${OC_PASSWORD}' --insecure-skip-tls-verify=true '${OC_API}' && oc apply --dry-run --validate -f '${filepath}'" \
+    || return 1
+    return 0
+}
+
+
+##
+# Handle lint forced files for unknown files.
+##
+function lint-forced
+{
+    local force
+    local linter_func
+    force="$1"
+    shift 1
+    [ $# -eq 0 ] && return 0
+    [ "$force" == "" ] && die "\$1 was expected to be some lint forced type"
+
+    case "$force" in
+        "--force-shellcheck" )
+            linter_func="lint-shellscript"
+            ;;
+        "--force-dockerfile" )
+            linter_func="lint-dockerfile"
+            ;;
+        "--force-yaml" )
+            linter_func="lint-yaml"
+            ;;
+        "--force-go" )
+            linter_func="lint-go"
+            ;;
+        "--force-kubeobject" )
+            linter_func="lint-kubeobject"
+            ;;
+        "--force-markdown" )
+            linter_func="lint-markdown"
+            ;;
+        * )
+            return 0
+            ;;
+    esac
+
+    "${linter_func}" "$@" || return 1
+    return 0
 }
 
 
@@ -148,7 +208,7 @@ Options could be:
                       not be auto-discovered.
   --force-markdown    Force lint a Markdown document.
 
-* By default lint all the files in the repository.  
+* By default lint all the files in the repository.
 EOF
     exit 0
 }
@@ -156,180 +216,98 @@ EOF
 
 function prepare-lists
 {
-    local files
-    local file
-
-    # array=()
-    # while IFS='' read -r line; do array+=("$line"); done < <(mycommand)
-    files=()
-    while IFS='' read -r line; do files+=("$line"); done < <( find . -name '*.sh' )
-    files=("${files[@]}" \
-           "build/bin/entrypoint" \
-           "build/bin/user_setup" \
-    )
-    SHELL_FILES=("${files[@]}")
-    debug-msg "SHELL_FILES=${SHELL_FILES[*]}"
-
-
-    files=()
-    while IFS='' read -r line; do files+=("$line"); done < <( find . -name '*.yaml' -o -name '*.yml' )
-    YAML_FILES=("${files[@]}")
-    debug-msg "YAML_FILES=${YAML_FILES[*]}"
-
-
-    files=()
-    while IFS='' read -r line; do files+=("$line"); done < <( find . -name 'Dockerfile' -o -name 'Dockerfile.*' )
-    DOCKERFILE_FILES=("${files[@]}")
-    debug-msg "DOCKERFILE_FILES=${DOCKERFILE_FILES[*]}"
-
-
-    files=()
-    while IFS='' read -r line; do files+=("$line"); done < <( find . -name '*.go' )
-    GO_FILES=("${files[@]}")
-    debug-msg "GO_FILES=${GO_FILES[*]}"
-
-
-    files=()
-    while IFS='' read -r line; do files+=("$line"); done < <( find . -name '*.md' )
-    MARKDOWN_FILES=("${files[@]}")
-    debug-msg "MARKDOWN_FILES=${MARKDOWN_FILES[*]}"
+    for filepath in "$@"
+    do
+        filename="$( basename "${filepath}" )"
+        case "${filename}" in
+            *.sh )
+                SHELL_FILES+=("${filepath}")
+                ;;
+            "Dockerfile" | Dockerfile.* )
+                DOCKERFILE_FILES+=("${filepath}")
+                ;;
+            *.md )
+                MARKDOWN_FILES+=("${filepath}")
+                ;;
+            *.go )
+                GO_FILES+=("${filepath}")
+                ;;
+            *.yaml | *.yml )
+                YAML_FILES+=("${filepath}")
+                ;;
+            * )
+                UNKNOWN_FILES+=("${filepath}")
+                ;;
+        esac
+    done
 }
 
 
 function cmd-lint-all
 {
     local reto
-    local shellscript_err_count
-    local yaml_err_count
-    local dockerfile_err_count
-    local go_err_count
-    local markdown_err_count
-    local err_count
-    prepare-lists
 
-    # Lint shell scripts
-    echo ">> Linting shell script files"
-    shellscript_err_count=0
-    for file in "${SHELL_FILES[@]}"
-    do
-        lint-shellscript "$file"
-        reto=$?
-        [ $reto -ne 0 ] && shellscript_err_count=$(( shellscript_err_count + 1 ))
-    done
-
-    # Lint YAML files
-    echo ">> Linting YAML files"
-    yaml_err_count=0
-    for file in "${YAML_FILES[@]}"
-    do
-        lint-yaml "$file"
-        reto=$?
-        [ $reto -ne 0 ] && yaml_err_count=$(( yaml_err_count + 1 ))
-    done
-
-    # Lint Dockerfile files
-    echo ">> Linting Dockerfile files"
-    dockerfile_err_count=0
-    for file in "${DOCKERFILE_FILES[@]}"
-    do
-        lint-dockerfile "$file"
-        reto=$?
-        [ $reto -ne 0 ] && dockerfile_err_count=$(( dockerfile_err_count + 1 ))
-    done
-
-    # Lint Go Files
-    echo ">> Linting GO files"
-    go_err_count=0
-    lint-go .
-    reto=$?
-    [ $reto -ne 0 ] && go_err_count=$(( go_err_count + 1 ))
-
-    # Lint Markdown Files
-    echo ">> Linting Markdown files"
-    markdown_err_count=0
-    for file in "${MARKDOWN_FILES[@]}"
-    do
-        lint-markdown "$file"
-        reto=$?
-        [ $reto -ne 0 ] && markdown_err_count=$(( markdown_err_count + 1 ))
-    done
-
-    err_count=$(( shellscript_err_count + yaml_err_count + dockerfile_err_count + go_err_count + markdown_err_count ))
-    return $err_count
-}
-
-
-function lint-forced
-{
-    local force
-    local filepath
-    force="$1"
-    filepath="$2"
-    [ "$force" == "" ] && die "\$1 was expected to be some lint forced type"
-    [ "$filepath" == "" ] && die "\$2 must be specified"
-
-    case "$force" in
-        "--force-shellcheck" )
-            lint-shellscript "${filepath}"
-            ;;
-        "--force-dockerfile" )
-            lint-dockerfile "${filepath}"
-            ;;
-        "--force-yaml" )
-            lint-yaml "${filepath}"
-            ;;
-        "--force-go" )
-            lint-go "${filepath}"
-            ;;
-        "--force-kubeobject" )
-            lint-kubeobject "${filepath}"
-            ;;
-        "--force-markdown" )
-            lint-markdown "${filepath}"
-            ;;
-        * )
-            ;;
-    esac
-}
-
-function cmd-lint-file-list
-{
-    local current_file
-    local filename
-    local err_count
+    if [ $# -gt 0 ]
+    then
+        prepare-lists "$@"
+    else
+        # shellcheck disable=SC2046
+        prepare-lists $( find . -name 'Dockerfile' -o -name 'Dockerfile.*' \
+                                -o -name '*.md' \
+                                -o -name '*.go' \
+                                -o -name '*.yaml' -o -name '*.yml' \
+                                -o -name '*.sh'
+                    )
+    fi
 
     err_count=0
-    while [ $# -gt 0 ]
-    do
-        current_file="$1"
-        shift 1
-        filename="$( basename "${current_file}" )"
 
-        if [ "${filename%%.sh}" != "${filename}" ]
+    # Linting shell script files
+    lint-shellscript "${SHELL_FILES[@]}"
+    reto=$?
+    [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
+
+    # Linting YAML files
+    lint-yaml "${YAML_FILES[@]}"
+    reto=$?
+    [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
+
+    # Linting Dockerfile files
+    lint-dockerfile "${DOCKERFILE_FILES[@]}"
+    reto=$?
+    [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
+
+    # Linting GO files
+    lint-go "${GO_FILES[@]}"
+    reto=$?
+    [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
+
+    # Linting Markdown files
+    lint-markdown "${MARKDOWN_FILES[@]}"
+    reto=$?
+    [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
+
+    [ ${#UNKNOWN_FILES[@]} -gt 0 ] && {
+        if [ "${FORCE}" == "" ]
         then
-            lint-shellscript "${current_file}"
-            reto=$?
-            [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
-        elif [ "${filename}" == "Dockerfile" ] \
-             || [ "${filename##Dockerfile.}" != "${filename}" ]
-        then
-            lint-dockerfile "${current_file}"
-            reto=$?
-            [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
+            echo "The following files are not linted: ${UNKNOWN_FILES[*]}"
         else
-            if [ "$FORCE" != "" ]
-            then
-                lint-forced "$FORCE" "${current_file}"
-                reto=$?
-                [ $reto -ne 0 ] && err_count=$(( err_count + 1 ))
-            else
-                warning-msg "The '${filename}' not linted"
-                err_count=$(( err_count + 1 ))
-            fi
+            lint-forced "${FORCE}" "${UNKNOWN_FILES[@]}"
         fi
-    done
+    }
 
     return $err_count
+}
+
+
+function cmd-run
+{
+    # Check help
+    [ "$1" == "help" ] && cmd-help
+
+    # Run the corresponding subcommand
+    cmd-lint-all "$@"
+    exit $?
 }
 
 
@@ -352,28 +330,11 @@ function check-args-and-run
                 ;;
         esac
     done
+    [ "${1##--}" != "${1}" ] && shift 1
 
     cmd-run "$@"
 }
 
-
-function cmd-run
-{
-    # Check help
-    [ "$1" == "help" ] && cmd-help
-
-    # Run the corresponding subcommand
-    if [ $# -eq 0 ]
-    then
-        echo ">> Linting all files in the repository"
-        cmd-lint-all
-        exit $?
-    else
-        echo ">> Linting a file list"
-        cmd-lint-file-list "$@"
-        exit $?
-    fi
-}
 
 # Check repository root path
 if [ ! -e "${PWD}/.git" ] \

--- a/devel/packages/debian-buster.txt
+++ b/devel/packages/debian-buster.txt
@@ -1,0 +1,1 @@
+debian-10.txt

--- a/devel/pre-commit.sh
+++ b/devel/pre-commit.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/sh
+
+yield()
+{
+	echo "$*" >&2
+}
+
+error_msg()
+{
+	yield "ERROR: $*"
+}
+
+die()
+{
+	err=$?
+	[ $err -eq 0 ] && err=127
+	error_msg "$@"
+	return $err
+}
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against="HEAD"
+else
+	# Initial commit: diff against an empty tree object
+	against="$( git hash-object -t tree /dev/null )"
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii="$( git config --type=bool hooks.allownonascii )"
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "${allownonascii}" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test "$( git diff --cached --name-only --diff-filter=A -z "${against}" \
+	         | LC_ALL=C tr -d '[ -~]\0' \
+		     | wc -c)" != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+This can cause problems if you want to work with people on other platforms.
+To be portable it is advisable to rename the file.
+If you know what you are doing you can disable this check using:
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached "${against}" -- || die "Remove the whitespaces and commit again"
+
+files=""
+for item in $( git diff-index --cached --name-only "${against}" 2>/dev/null )
+do
+	files="${files} ${item}"
+done
+
+echo "Linting:${files}"
+# shellcheck disable=SC2086
+./devel/lint.sh ${files}
+exit $?

--- a/tests/test-install-local-tools.sh
+++ b/tests/test-install-local-tools.sh
@@ -249,6 +249,7 @@ function run-test
     fi
     reto="$( $oci container wait "${container_id}" 2>/dev/null )"
     $oci container rm -f "${container_id}" &>/dev/null
+    # shellcheck disable=SC2086
     return $reto
 }
 
@@ -279,7 +280,9 @@ for image in "${CONTAINER_IMAGES[@]}"
 do
     for index in "${!MATRIX_FLAGS[@]}"
     do
+        # shellcheck disable=SC2086
         [ $index -lt $START_INDEX ] && continue
+        # shellcheck disable=SC2086
         [ $index -gt $END_INDEX ] && continue
         # shellcheck disable=SC2206
         CURRENT_FLAGS=(${MATRIX_FLAGS[$index]})
@@ -295,7 +298,9 @@ do
     # Print result report
     for index in "${!MATRIX_FLAGS[@]}"
     do
+        # shellcheck disable=SC2086
         [ $index -lt $START_INDEX ] && continue
+        # shellcheck disable=SC2086
         [ $index -gt $END_INDEX ] && continue
         if [ ${RESULT_MATRIX[$index]} -eq ${MATRIX_EXPECTED[$index]} ]
         then

--- a/tools.go
+++ b/tools.go
@@ -1,5 +1,5 @@
 // +build tools
 
-// Place any runtime dependencies as imports in this file.
-// Go modules will be forced to download and install them.
+// Package tools - Place any runtime dependencies as imports in this
+// file. Go modules will be forced to download and install them.
 package tools

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 package version
 
 var (
+	// Version for the oeprator
 	Version = "0.0.1"
 )


### PR DESCRIPTION
- Appending the local hooks I realized some issues at lint.sh, I have fixed them too.
- I have adapted the pipeline for using the lint.sh for the linter stage too.
All the linters are using the same script now to keep the behavior consistent (git hook, pipeline, and development environment).
- I have made changes to lint.sh to allow using podman and docker (support Ubuntu 18.04 for the pipeline).
- I have updated install-local-tools.sh to support Ubuntu 18.04 (this is the default OS used by default when running the pipeline in github).
- Some minor fixes related to lint hints.
- I have re-factored lint.sh script to improve the time consumed by the linter.sh (reduce the number of containers launched for the lint stage). This impact quite positive when linting the files in a commit through the git hook.
- "go install" statement changed again to "go get" because that was failing in the pipeline, when I integrated lint.sh in the pipeline.