### PR TITLE
pipeline: Add build stage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,15 @@
 ---
+# Predefined variables for github:
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
+
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#name
 name: Main
 
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#on
 # yamllint disable-line rule:truthy
-on: [push, pull_request]
+on:
+  - push
+  - pull_request
 
 # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobs
 jobs:
@@ -15,23 +20,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Gather environment information
+        env:
+          IMG_BASE: "${{ secrets.IMG_BASE }}"
         run: |
           env
           go env
           go version
 
-      # - name: Install tools
-      #   run: |
-      #     export FLAG_INSTALL_VSCODE=NO
-      #     export FLAG_INSTALL_CRC=NO
-      #     export GOPATH="$PWD/go"
-      #     [ -e "$GOPATH" ] || mkdir -p $GOPATH
-      #     ./devel/install-local-tools.sh
-
-      # - uses: actions/upload-artifact@v2
-      #   with:
-      #     name: local-tools
-      #     path: ./go
+      - uses: actions/upload-artifact@v2
+        with:
+          name: image.txt
+          path: image.txt
 
   lint-golang:
     name: Lint golang code
@@ -48,11 +47,10 @@ jobs:
         run: |
           [ "$GOPATH" != "" ] || export GOPATH="$( go env GOPATH )"
           go get -u golang.org/x/lint/golint
-          # go install
           make lint
 
-  lint-files:
-    name: Lint all possible files in the repository but golang
+  lint-extra-files:
+    name: Lint extra files in the repository
     needs: [environment]
 
     # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
@@ -72,3 +70,83 @@ jobs:
         run: |
           ./devel/lint.sh  $( find . -name 'Dockerfile' \
           -o -name 'Dockerfile.*' )
+
+  build:
+    name: Build stage
+    needs: [lint-golang, lint-extra-files]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@master
+        with:
+          go-version: 1.14
+        id: go
+
+      - name: Install dependencies
+        env:
+          # yamllint disable-line rule:line-length
+          INSTALL_KUSTOMIZE_URL: "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+          # yamllint disable-line rule:line-length
+          OPERATOR_SDK_URL: "https://github.com/operator-framework/operator-sdk/releases/download/v1.0.0/operator-sdk-v1.0.0-x86_64-linux-gnu"
+          GO111MODULE: "on"
+        run: |
+          curl -s "${INSTALL_KUSTOMIZE_URL}" | bash
+          go install -i
+          go get golang.org/x/lint/golint
+          go get github.com/kisielk/errcheck
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0
+
+      # https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow
+      - name: Build
+        env:
+          GO111MODULE: "on"
+          IMG_BASE: "${{ secrets.IMG_BASE }}"
+          DOCKER_AUTH: "${{ secrets.DOCKER_AUTH }}"
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          export TAG="${GITHUB_SHA}"
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]
+          then
+            export IMG_BASE="local/freeipa-operator"
+          fi
+          export IMG="${IMG_BASE}:${TAG}"
+
+          echo ">>> Building operator binary"
+          make generate
+          go build -o bin/manager main.go
+
+          echo ">>> Building container image"
+          docker build . -t ${IMG}
+          make docker-save
+
+          # The container image will not be pushed when building on a PR,
+          # because the secrets are not accessible from the PR (for
+          # security reasons), which make not possible to login into the
+          # container image registry.
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]
+          then
+            echo ">>> Pushing container image"
+            DOCKER_REGISTRY="${IMG_BASE%%/*}"
+            [ -e "${HOME}/.docker" ] || mkdir -p "${HOME}/.docker"
+            cat > "$HOME/.docker/config.json" <<< "${DOCKER_AUTH}"
+            docker login "${DOCKER_REGISTRY}"
+            # rm is not accidental here; it is removed if the push
+            # was successful, to avoid it is stored as an artefact
+            # in github.
+            docker push "${IMG}" \
+            && rm -vf docker-image-freeipa-operator.tar.gz
+          fi
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: docker-image-${{ github.sha }}
+          path: docker-image-freeipa-operator.tar.gz
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: manager-${{ github.sha }}
+          path: bin

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ bin
 *.swp
 *.swo
 *~
+
+# Ignore docker-image artifact generated in Makefile
+docker-image-freeipa-operator.tar.gz
+
+# Ignore local go directory
+/go

--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -1,0 +1,19 @@
+# DevOps documentation
+
+## Setting up the pipeline
+
+The current github pipeline require some settings to let it run successfully.
+You will need to set up the following secrets:
+
+- DOCKER_AUTH: The file content with the credentials to login into the
+  container image registry. This is used to create the
+  `$HOME/.docker/config.json` file.
+- IMG_BASE: The base name for your image. This could be something like:
+  - `quay.io/freeipa/freeipa-operator`.
+  - `docker.io/freeipa/freeipa-operator`.
+  - `quay.io/avisied0/my-freeipa-operator`.
+  This provide flexibility, and allow that forked repositories could made
+  deliveries on their own image registries, or different repository.
+
+The deliveries will be stored at:
+[quay.io/freeipa/freeipa-operator](https://quay.io/repository/freeipa/freeipa-operator).

--- a/config/crd/bases/idmocp.redhat.com_idms.yaml
+++ b/config/crd/bases/idmocp.redhat.com_idms.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -21,20 +22,14 @@ spec:
       description: IDM is the Schema for the idms API
       properties:
         apiVersion:
-          description: >
-            APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the
-            latest internal value, and may reject unrecognized values.
-            More info:
-            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: >
-            Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the
-            client submits requests to. Cannot be updated. In CamelCase.
-            More info:
-            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -52,14 +47,14 @@ spec:
                 type: string
               type: array
           required:
-            - servers
+          - servers
           type: object
       type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true
 status:
   acceptedNames:
     kind: ""

--- a/devel/lint.sh
+++ b/devel/lint.sh
@@ -216,6 +216,7 @@ EOF
 
 function prepare-lists
 {
+    local DIRNAME
     for filepath in "$@"
     do
         [ ! -e "$filepath" ] && continue
@@ -234,7 +235,12 @@ function prepare-lists
                 GO_FILES+=("${filepath}")
                 ;;
             *.yaml | *.yml )
-                YAML_FILES+=("${filepath}")
+                DIRNAME="$( dirname "$filepath" )"
+                DIRNAME="${DIRNAME#./}"
+                if [ "${DIRNAME#config/crd/}" == "${DIRNAME}" ]
+                then
+                    YAML_FILES+=("${filepath}")
+                fi
                 ;;
             * )
                 UNKNOWN_FILES+=("${filepath}")
@@ -257,7 +263,14 @@ function cmd-lint-all
                                 -o -name '*.md' \
                                 -o -name '*.go' \
                                 -o -name '*.sh'; \
-                          find ./config -name '*.yaml' \
+                          find ./config/certmanager -name '*.yaml'; \
+                          find ./config/crd -maxdepth 1 -name '*.yaml'; \
+                          find ./config/default -name '*.yaml'; \
+                          find ./config/manager -name '*.yaml'; \
+                          find ./config/prometheus -name '*.yaml'; \
+                          find ./config/rbac -name '*.yaml'; \
+                          find ./config/samples -name '*.yaml'; \
+                          find ./config/webhook -name '*.yaml'; \
                         )
     fi
 


### PR DESCRIPTION
A build stage have been created in the pipeline which allow to generate the binary and the container image for the operator, and a few changes more:
- Lint stage is divided in two stage to allow run them in parallel.
- local repository go directory is added to .gitignore file; if you deploy the go modules in your repository directory, this avoid noise in the git status report.
- Prepare Makefile for a more flexible delivery, and add rules for save/load container images.
- Remove false negative when installing the tools.
- Filter some yaml files from lint process as they are auto-generated.