### PR TITLE
Add investigation files for enabling container_manage_cgroup sebool

### DIFF
--- a/miscelanea/001-enable-container-manage-cgroup-sebool/10-enable-container-manage-cgroup-sebool.yaml
+++ b/miscelanea/001-enable-container-manage-cgroup-sebool/10-enable-container-manage-cgroup-sebool.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 10-enable-container-manage-cgroup-sebool
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+        - name: setsebool-container-manage-cgroup.service
+          enabled: true
+          contents: |
+            [Unit]
+            Before=kubelet.service
+            [Service]
+            Type=oneshot
+            ExecStart=setsebool container_manage_cgroup true
+            RemainAfterExit=yes
+            [Install]
+            WantedBy=multi-user.target

--- a/miscelanea/001-enable-container-manage-cgroup-sebool/10-wrong-enable-container-manage-cgroup-sebool.yaml
+++ b/miscelanea/001-enable-container-manage-cgroup-sebool/10-wrong-enable-container-manage-cgroup-sebool.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 10-enable-container-manage-cgroup-sebool
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+      systemd:
+        units:
+          - name: setsebool-container-manage-cgroup.service
+            enabled: true
+            contents: |
+              [Unit]
+              Before=kubelet.service
+              [Service]
+              Type=oneshot
+              ExecStart=setsebool container_manage_cgroup true
+              RemainAfterExit=yes
+              [Install]
+              WantedBy=multi-user.target

--- a/miscelanea/001-enable-container-manage-cgroup-sebool/EnablingSebool.md
+++ b/miscelanea/001-enable-container-manage-cgroup-sebool/EnablingSebool.md
@@ -5,9 +5,13 @@ methods:
 
 - **Direct change by using setsebool** in the worker nodes one by one: This
   change the sebool but it only makes sense in a development environement.
-- **Using Tunned Operator by a Tuned object**: This was a wrong path but the
-  operator provide interesting features to keep in mind for the future. Look
-  at [tune-sebool.yaml](tune-sebool.yaml) file for more information.
+- **Using Tuned Operator by a Tuned object**: This is the wrong path to make
+  this changes, as we can see at:
+  - [Is this operator capable of setting sebools?](https://github.com/openshift/cluster-node-tuning-operator/issues/89).
+  - [Manage sebooleans in MachineConfig](https://github.com/openshift/machine-config-operator/issues/852).
+  However, the operator provide interesting features to keep in mind for the
+  future. Look at [tune-sebool.yaml](tune-sebool.yaml) file for more
+  information.
 - **Using Machine Config Operator by a MachineConfig object**: This has been
   the final path which has worked for us. It provides a way to change
   the sebool using the Kubernetes way.

--- a/miscelanea/001-enable-container-manage-cgroup-sebool/EnablingSebool.md
+++ b/miscelanea/001-enable-container-manage-cgroup-sebool/EnablingSebool.md
@@ -1,0 +1,36 @@
+# Enabling sebool
+
+To enable the container_manage_cgroup sebool has been tried 3 different
+methods:
+
+- **Direct change by using setsebool** in the worker nodes one by one: This
+  change the sebool but it only makes sense in a development environement.
+- **Using Tunned Operator by a Tuned object**: This was a wrong path but the
+  operator provide interesting features to keep in mind for the future. Look
+  at [tune-sebool.yaml](tune-sebool.yaml) file for more information.
+- **Using Machine Config Operator by a MachineConfig object**: This has been
+  the final path which has worked for us. It provides a way to change
+  the sebool using the Kubernetes way.
+
+To enable the container_manage_cgroup sebool, just run as administrator:
+
+```shell
+oc create -f 10-enable-container-manage-cgroup-sebool.yaml
+```
+
+To disable the container_manage_cgroup sebool, just run as administrator:
+
+```shell
+oc delete -f 10-enable-container-manage-cgroup-sebool.yaml
+```
+
+## Contents
+
+- [10-enable-container-manage-cgroup-sebool.yaml](10-enable-container-manage-cgroup-sebool.yaml)
+  contains the MachineConfig object that works.
+- [10-wrong-enable-container-manage-cgroup-sebool.yaml](10-wrong-enable-container-manage-cgroup-sebool.yaml)
+  a wrong version from the above, which was a pain in the neck as no traces
+  were found about the mistake in the file. To provide some input to the
+  MCO team if it could be enhanced to print out some log trace about it.
+- [tune-sebool.yaml](tune-sebool.yaml) file is an example trying to use
+  Tune Operator, which does not support managing sebool.

--- a/miscelanea/001-enable-container-manage-cgroup-sebool/EnablingSebool.md
+++ b/miscelanea/001-enable-container-manage-cgroup-sebool/EnablingSebool.md
@@ -33,8 +33,10 @@ oc delete -f 10-enable-container-manage-cgroup-sebool.yaml
 - [10-enable-container-manage-cgroup-sebool.yaml](10-enable-container-manage-cgroup-sebool.yaml)
   contains the MachineConfig object that works.
 - [10-wrong-enable-container-manage-cgroup-sebool.yaml](10-wrong-enable-container-manage-cgroup-sebool.yaml)
-  a wrong version from the above, which was a pain in the neck as no traces
-  were found about the mistake in the file. To provide some input to the
-  MCO team if it could be enhanced to print out some log trace about it.
+  a wrong version from the above, which replay the situation where no
+  traces or validation error are got when applying the object making
+  difficult to detect what is wrong in the object definition. Using this
+  to provide some input to the MCO team if it could be enhanced to print out
+  some log traces about it.
 - [tune-sebool.yaml](tune-sebool.yaml) file is an example trying to use
   Tune Operator, which does not support managing sebool.

--- a/miscelanea/001-enable-container-manage-cgroup-sebool/tune-sebool.yaml
+++ b/miscelanea/001-enable-container-manage-cgroup-sebool/tune-sebool.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: container-manage-cgroup
+spec:
+  profile:
+    - data: |
+        [main]
+        summary=A custom OpenShift sebool profile
+        [selinux]
+        container_manage_cgroup=1
+      name: enable-container-manage-cgroup
+  recommend: []

--- a/miscelanea/README.md
+++ b/miscelanea/README.md
@@ -1,0 +1,10 @@
+# Miscelanea
+
+This directory contain different proof of concepts that have been made by hand
+as part of investigations for freeipa-operator.
+
+Contents:
+
+- **[001-enable-container-manage-cgroup-sebool](001-enable-container-manage-cgroup-sebool/EnablingSebool.md)**:
+  Provide the MachineConfig object which enable the container_manage_cgroup
+  sebool.


### PR DESCRIPTION
It is just the set of files used as proof of concept to enable the container_manage_cgroup sebool.

Not sure about the layout to be kept, so this could change in the future; just a way to store this information into the repository.