### PR TITLE
linter: Add lintignore feature and bypass mechanism

### DIFF
--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -17,3 +17,7 @@ You will need to set up the following secrets:
 
 The deliveries will be stored at:
 [quay.io/freeipa/freeipa-operator](https://quay.io/repository/freeipa/freeipa-operator).
+
+- A lint.ignore mechanism is available. Just editing the file
+  `devel/lint.ignore`, and adding the files to be ignored. The mechanism
+  can be bypassed by setting `LINT_FILTER_BYPASS=1`.

--- a/devel/install-local-tools.sh
+++ b/devel/install-local-tools.sh
@@ -422,10 +422,8 @@ EOF
 }
 
 
-[ ! -e .git/hooks/pre-commit ] && {
-    echo ">> Installing git-hooks"
-    cp -f ./devel/pre-commit.sh .git/hooks/pre-commit
-}
+echo ">> Installing git-hooks"
+cp -f ./devel/pre-commit.sh .git/hooks/pre-commit
 
 
 unset GOPATH

--- a/devel/lint.ignore
+++ b/devel/lint.ignore
@@ -1,0 +1,1 @@
+miscelanea/003-scc-and-caps/README.md

--- a/devel/pre-commit.sh
+++ b/devel/pre-commit.sh
@@ -62,8 +62,12 @@ do
 	files="${files} ${item}"
 done
 
-echo "Linting:${files}"
-# shellcheck disable=SC2086
-./devel/lint.sh ${files}
-exit $?
+if [ "${files}" != "" ]; then
+    echo "Linting:${files}"
+    # shellcheck disable=SC2086
+    ./devel/lint.sh ${files}
+    exit $?
+else
+    exit 0
+fi
 


### PR DESCRIPTION
Add support for filter files in the repository to avoid linting
them, and add a bypass mechanism which disable the filter, allowing
to filter files that was being filtered normally.
The bypass mechanism is enabled by setting LINT_FILTER_BYPASS=1