### PR TITLE
pipeline: Add dive tool support to the repository and documentation

### DIFF
--- a/.dive-ci.yml
+++ b/.dive-ci.yml
@@ -1,0 +1,17 @@
+---
+# https://github.com/wagoodman/dive#ci-integration
+rules:
+  # If the efficiency is measured below X%, mark as failed.
+  # Expressed as a ratio between 0-1.
+  lowestEfficiency: 0.95
+
+  # If the amount of wasted space is at least X or larger than X, mark as
+  # failed.
+  # Expressed in B, KB, MB, and GB.
+  highestWastedBytes: 20MB
+
+  # If the amount of wasted space makes up for X% or more of the image, mark as
+  # failed.
+  # Note: the base image layer is NOT included in the total image size.
+  # Expressed as a ratio between 0-1; fails if the threshold is met or crossed.
+  highestUserWastedPercent: 0.20

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   environment:
     name: Gather information about the environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -32,17 +32,12 @@ jobs:
           go env
           go version
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: image.txt
-          path: image.txt
-
   lint-golang:
     name: Lint golang code
     needs: [environment]
 
-    # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-latest
+    # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: ubuntu-20.04
 
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps
     steps:
@@ -58,8 +53,8 @@ jobs:
     name: Lint extra files in the repository
     needs: [environment]
 
-    # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
-    runs-on: ubuntu-latest
+    # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: ubuntu-20.04
 
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps
     steps:
@@ -80,7 +75,7 @@ jobs:
     name: Build stage
     needs: [lint-golang, lint-extra-files]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -90,6 +85,11 @@ jobs:
         with:
           go-version: 1.14
         id: go
+
+      - name: Clean container objects
+        run: |
+          docker image prune --force
+          docker container prune --force
 
       - name: Install dependencies
         env:
@@ -104,6 +104,7 @@ jobs:
           go get golang.org/x/lint/golint
           go get github.com/kisielk/errcheck
           go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30.0
+          # GO111MODULE=off go get -v github.com/wagoodman/dive
 
       # https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow
       - name: Build
@@ -114,7 +115,8 @@ jobs:
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
           export TAG="${GITHUB_SHA}"
-          if [ "${GITHUB_EVENT_NAME}" == "pull_request" ]
+          export CONTAINER_IMAGE_FILE="${IMG_BASE##*/}.tar"
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]
           then
             export IMG_BASE="local/freeipa-operator"
           elif [ "${GITHUB_EVENT_NAME}" == "schedule" ]
@@ -128,8 +130,13 @@ jobs:
           go build -o bin/manager main.go
 
           echo ">>> Building container image"
-          docker build . -t ${IMG}
-          make docker-save
+          make container-build
+
+          echo ">>> Saving docker-archive"
+          make container-save
+
+          echo ">>> Checking image layer sizes"
+          make dive
 
           # The container image will not be pushed when building on a PR,
           # because the secrets are not accessible from the PR (for
@@ -145,14 +152,14 @@ jobs:
             # rm is not accidental here; it is removed if the push
             # was successful, to avoid it is stored as an artefact
             # in github.
-            docker push "${IMG}" \
-            && rm -vf docker-image-freeipa-operator.tar.gz
+            make container-push \
+            && rm -vf ${CONTAINER_IMAGE_FILE}.gz
           fi
 
       - uses: actions/upload-artifact@v2
         with:
-          name: docker-image-${{ github.sha }}
-          path: docker-image-freeipa-operator.tar.gz
+          name: freeipa-operator-${{ github.sha }}.tar
+          path: freeipa-operator.tar
 
       - uses: actions/upload-artifact@v2
         with:

--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -21,3 +21,17 @@ The deliveries will be stored at:
 - A lint.ignore mechanism is available. Just editing the file
   `devel/lint.ignore`, and adding the files to be ignored. The mechanism
   can be bypassed by setting `LINT_FILTER_BYPASS=1`.
+
+## Checking image size
+
+The pipeline launch dive tool to verify the layer size of the image generated
+for the operator. This tool can be launched from the workstation with just:
+
+```shell
+make container-build container-save dive
+```
+
+The settings for dive tool are located at .dive-ci.yml which are the settings
+used in the pipeline. The helper script `./devel/dive.sh` use the same
+settings; the command `make dive` is calling to the helper script under the
+hood.

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Experimental freeipa-operator for Freeipa.
 
    ```shell
    kubectl login https://my-cluster:6443
-   make docker-build IMG=quay.io/freeipa/freeipa-operator:dev-test
+   make container-build IMG=quay.io/freeipa/freeipa-operator:dev-test
    podman login quay.io
-   make docker-push IMG=quay.io/freeipa/freeipa-operator:dev-test
+   make container-push IMG=quay.io/freeipa/freeipa-operator:dev-test
    make deploy IMG=quay.io/freeipa/freeipa-operator:dev-test
    ```
 

--- a/devel/dive.sh
+++ b/devel/dive.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+IMG_NAME="freeipa-operator"
+CONTAINER_IMAGE_FILE="${CONTAINER_IMAGE_FILE:-${IMG_NAME}.tar}"
+
+function yield
+{
+    echo "$*" >&2
+}
+
+function die
+{
+    local err=$?
+    [ $err -eq 0 ] && err=127
+    yield "ERROR: $*"
+    exit $err
+}
+
+function verbose
+{
+    yield "$@"
+    "$@"
+}
+
+if command -v podman &>/dev/null; then oci="podman"
+elif command -v docker &>/dev/null; then oci="docker"
+else die "No podman nor docker were found"
+fi
+
+args="--ci"
+[ -e .dive-ci.yml ] && args+=" --ci-config .dive-ci.yml"
+if [ "${CONTAINER_IMAGE_FILE}" != "" ] && [ -e "${CONTAINER_IMAGE_FILE}" ]; then
+    args+=" --source docker-archive ${CONTAINER_IMAGE_FILE}"
+    # shellcheck disable=SC2086
+    verbose $oci run --rm -it \
+                   -v "$PWD:$PWD" \
+                   -w "$PWD" \
+                   wagoodman/dive:latest \
+                   ${args} "$@"
+else
+    case "$oci" in
+        "docker" )
+            args+=" --source docker"
+            ;;
+        "podman" )
+            args+=" --source podman"
+            ;;
+    esac
+    # shellcheck disable=SC2086
+    verbose dive ${args} "$@"
+fi
+

--- a/devel/install-local-tools.sh
+++ b/devel/install-local-tools.sh
@@ -225,6 +225,9 @@ function install-go-tools
     # Install kustomize
     # install-kustomize-from-source || die "Installing kustomize"
     GO111MODULE=on verbose go get sigs.k8s.io/kustomize/kustomize/v3@v3.2.3 || die "Installing kustomize"
+
+    # Install dive
+    GO111MODULE=off verbose go get -v github.com/wagoodman/dive || die "Installing dive"
 } # install-go-tools
 
 


### PR DESCRIPTION
Integrate [dive](https://github.com/wagoodman/dive) tool in the pipeline:
- Makefile and standalone script so it can be used from different places depending on each situation.
- The usage has been documented at DEVOPS.md documentation.
- Change rule naming in Makefile moving from docker to more abstract container runtime naming (just container).
- Improve consistency in the pipeline by using directly the Makefile rules whenever is possible, so developer and pipeline use the same commands.