### PR TITLE
linter: Validate OpenShift objects

### DIFF
--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -22,6 +22,11 @@ The deliveries will be stored at:
   `devel/lint.ignore`, and adding the files to be ignored. The mechanism
   can be bypassed by setting `LINT_FILTER_BYPASS=1`.
 
+- For validating K8S objects created by kustomize when launching `make lint`,
+  or `./devel/lint.sh` script, we need to be logged in the
+  cluster or set the variables **OC_USERNAME**, **OC_PASSWORD** and
+  **OC_API_URL**.
+
 ## Checking image size
 
 The pipeline launch dive tool to verify the layer size of the image generated

--- a/devel/check-k8s.sh
+++ b/devel/check-k8s.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+source ./devel/include/verbose.inc
+
+if [ "${OC_USERNAME}" != "" ] && [ "${OC_PASSWORD}" != "" ] && [ "${OC_API_URL}" != "" ]; then
+    oc login -u "${OC_USERNAME}" -p "${OC_PASSWORD}" "${OC_API_URL}" \
+    || die "Failed to log in the cluster"
+else
+    oc whoami &>/dev/null \
+    || die "You should be logged in the cluster before run this script"
+fi
+
+yield -n ">> " && verbose kustomize build config/default/ | kubectl create --dry-run --validate -f - \
+&& yield -n ">> " && verbose kustomize build config/crd/ | kubectl create --dry-run --validate -f - \
+&& yield -n ">> " && verbose kustomize build config/manager/ | kubectl create --dry-run --validate -f - \
+&& yield -n ">> " && verbose kustomize build config/prometheus/ | kubectl create --dry-run --validate -f - 

--- a/devel/include/verbose.inc
+++ b/devel/include/verbose.inc
@@ -19,7 +19,7 @@ VERBOSE=${VERBOSE:-$VERBOSE_DEFAULT}
 ##
 function yield
 {
-    echo "$*" >&2
+    echo "$@" >&2
 } # yield
 
 
@@ -100,3 +100,12 @@ function assert
     "$@" || die "Assertion failed at ${FUNCNAME[1]}: $*"
 } # assert
 
+
+##
+# Print the command to be launched, and afterward execute it.
+##
+function verbose
+{
+    yield "$@"
+    "$@"
+}

--- a/devel/lint.sh
+++ b/devel/lint.sh
@@ -265,6 +265,15 @@ function prepare-lists
 }
 
 
+function can-run-check-k8s
+{
+    command -v oc &>/dev/null || return 1
+    oc whoami &>/dev/null && return 0
+    [ "${OC_USERNAME}" != "" ] && [ "${OC_PASSWORD}" != "" ] && [ "${OC_API_URL}" != "" ] && return 0
+    return 1
+}
+
+
 function cmd-lint-all
 {
     local reto
@@ -324,6 +333,13 @@ function cmd-lint-all
             lint-forced "${FORCE}" "${UNKNOWN_FILES[@]}"
         fi
     }
+
+    # Validate kubernetes objects if possible
+    if can-run-check-k8s; then
+        ./devel/check-k8s.sh || err_count=$(( err_count + 1 ))
+    else
+        warning-msg "It can not run validation on k8s kustomize objects"
+    fi
 
     return $err_count
 }

--- a/devel/pre-commit.sh
+++ b/devel/pre-commit.sh
@@ -15,7 +15,7 @@ die()
 	err=$?
 	[ $err -eq 0 ] && err=127
 	error_msg "$@"
-	return $err
+	exit $err
 }
 
 if git rev-parse --verify HEAD >/dev/null 2>&1


### PR DESCRIPTION
- Add the `./devel/check-k8s.sh` script for validating the k8s objects generated by kustomize.
- Add integration of the above script in `lint.sh` script.
- Document the script at **DEVOPS.md** file.
- The validation will be launched on the scenarios below:
  - When running `./devel/check-k8s.sh`.
  - When running `./devel/lint.sh` and we are logged in a cluster or provide the environment variables with the credentials.
  - When the pre-commit git hook is executed (if it was set-up), as it calls internally to `./devel/lint.sh`.
  - When the pipeline execute `./devel/lint.sh` and the credentials to log in to the cluster exists.