### PR TITLE
Update `test` target to use envtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ docker-image-freeipa-operator.tar.gz
 
 # Ignore local go directory
 /go
+
+# Ignore directory containing envtest binaries
+testbin/*

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,11 @@ all: manager
 FORCE:
 
 # Run tests
+ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 test: generate fmt vet manifests
-	go test ./... -coverprofile cover.out
+	mkdir -p "${ENVTEST_ASSETS_DIR}"
+	test -f "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" || curl -sSLo "${ENVTEST_ASSETS_DIR}/setup-envtest.sh" https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
+	source "${ENVTEST_ASSETS_DIR}/setup-envtest.sh"; fetch_envtest_tools "$(ENVTEST_ASSETS_DIR)"; setup_envtest_env "$(ENVTEST_ASSETS_DIR)"; go test ./... -coverprofile cover.out
 
 # Build manager binary
 manager: generate fmt vet


### PR DESCRIPTION
https://master.sdk.operatorframework.io/docs/building-operators/golang/references/envtest-setup/

Fixes: #19