### PR TITLE
poc: deploy freeipa in one pod

### DIFF
--- a/miscelanea/005-deploy-in-one-pod/Dockerfile
+++ b/miscelanea/005-deploy-in-one-pod/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/freeipa/freeipa-server:centos-8
+
+ENV KRB5_TRACE=/dev/console
+
+# Workaround for running systemd mode from podman
+RUN mkdir /usr/sbin/original \
+    && ln -svf /usr/lib/systemd/systemd /usr/sbin/original/init \
+    && rm /usr/sbin/init
+COPY init-wrapper.sh /usr/sbin/init
+COPY init-data /usr/loca/sbin/init
+
+# Enable debug
+COPY gssproxy.conf /data-template/etc/gssproxy/gssproxy.conf
+
+VOLUME /data
+
+ENTRYPOINT ["/usr/sbin/init"]

--- a/miscelanea/005-deploy-in-one-pod/Makefile
+++ b/miscelanea/005-deploy-in-one-pod/Makefile
@@ -1,0 +1,156 @@
+# This makefile make life easier for playing with the different
+# proof of concepts.
+
+# Customizable cluster domain for deploying wherever we want
+CLUSTER_DOMAIN?=permanent.idmocp.lab.eng.rdu2.redhat.com
+REALM?=APPS.$(shell echo $(CLUSTER_DOMAIN) | tr  '[:lower:]' '[:upper:]')
+TIMESTAMP?=$(shell date +%Y%m%d%H%M%S)
+
+# Set the container runtime interface
+ifneq (,$(shell bash -c "command -v podman 2>/dev/null"))
+DOCKER?=podman
+else
+ifneq (,$(shell bash -c "command -v docker 2>/dev/null"))
+DOCKER?=docker
+else
+ifeq (,$(DOCKER))
+$(error DOCKER is not set)
+endif
+endif
+endif
+
+NAMESPACE=$(shell oc project -q)
+ifeq (,$(NAMESPACE))
+$(error Not project indicated)
+endif
+
+AWAIT_TIMEOUT?=10
+FREEIPA_containers=init-container-uuid init-uid-gid-base main
+
+APP?=$(NAMESPACE)
+CONTAINERS="$(FREEIPA_containers)"
+# Change DOCKER_IMAGE on your pipeline settings to point to your upstream
+DOCKER_IMAGE?=quay.io/freeipa/freeipa-openshift-container:freeipa-server
+
+
+default: help
+
+
+.PHONY: FORCE
+FORCE:
+
+.PHONY: help
+help: FORCE
+	@echo "Available commands:"
+	@echo "    container-build"
+	@echo "    container-push"
+	@echo "    container-remove"
+	@echo "    app-validate"
+	@echo "    app-deploy"
+	@echo "    app-delete"
+	@echo "    get-info"
+
+# Check that cluster domain is not empty
+.PHONY: check-cluster-domain-not-empty
+ifeq (,$(CLUSTER_DOMAIN))
+check-cluster-domain-not-empty: FORCE
+	@echo "'CLUSTER_DOMAIN' must be specified; Try 'CLUSTER_DOMAIN=my.cluster.domain.com make $$0'"
+	@exit 1
+else
+check-cluster-domain-not-empty:
+endif
+
+# Check logged in OpenShift cluster
+.PHONY: check-logged-in-openshift
+ifeq (,$(shell oc whoami 2>/dev/null))
+check-logged-in-openshift: FORCE
+	@echo "ERROR: You must be logged in OpenShift cluster. Try 'oc login https://mycluster' matching your cluster API endpoint"
+	@exit 1
+else
+check-logged-in-openshift:
+endif
+
+# Check APP is not empty
+.PHONY: check-app-not-empty
+ifeq (,$(APP))
+check-app-not-empty: FORCE
+	@echo "'APP' must be specified; Try 'APP=my-app-id make $0'"
+	@exit 1
+else
+check-app-not-empty:
+endif
+
+# Check DOCKER_IMAGE is not empty
+.PHONY: check-docker-image-not-empty
+ifeq (,$(DOCKER_IMAGE))
+check-docker-image-not-empty: FORCE
+	@echo "'DOCKER_IMAGE' must be defined. Eg: 'export DOCKER_IMAGE=quay.io/myusername/freeipa-server:latest'"
+	@exit 1
+else
+check-docker-image-not-empty:
+endif
+
+# Build the container image
+.PHONY: container-build
+container-build: check-docker-image-not-empty Dockerfile
+	$(DOCKER) build -t $(DOCKER_IMAGE) -f Dockerfile .
+
+# Push the container image to the container registry
+.PHONY: container-push
+container-push: check-docker-image-not-empty FORCE
+	$(DOCKER) push $(DOCKER_IMAGE)
+
+# Remove container image from the local storage
+.PHONY: container-remove
+container-remove: check-docker-image-not-empty FORCE
+	$(DOCKER) image rm $(DOCKER_IMAGE)
+
+# Validate kubernetes object for the app
+.PHONY: app-validate
+app-validate: check-logged-in-openshift check-app-not-empty freeipa.yaml freeipa-admin.yaml FORCE
+	oc create -f freeipa.yaml --dry-run=client --validate=true \
+	&& oc create -f freeipa-admin.yaml --dry-run=client --validate=true
+
+# Deploy the application
+.PHONY: app-deploy
+app-deploy: check-cluster-domain-not-empty check-app-not-empty check-docker-image-not-empty check-logged-in-openshift freeipa.yaml freeipa-admin.yaml app-validate FORCE
+	oc create user freeipa
+	oc create -f freeipa-admin.yaml
+	# oc adm policy add-scc-to-user freeipa -z system:serviceaccount:$(NAMESPACE):freeipa
+	oc adm policy add-scc-to-user freeipa -z freeipa
+	oc create -f freeipa.yaml --as freeipa
+	oc get routes/freeipa
+
+# Force manifest regeneration
+freeipa-admin.yaml: freeipa-admin.yaml.envsubst FORCE
+	DOLLAR='$$' CLUSTER_DOMAIN="$(CLUSTER_DOMAIN)" NAMESPACE=$(NAMESPACE) DOCKER_IMAGE=$(DOCKER_IMAGE) APP=$(APP) envsubst < "$<" > "$@"
+
+# Force manifest regeneration
+freeipa.yaml: freeipa.yaml.envsubst FORCE
+	DOLLAR='$$' TIMESTAMP=$(TIMESTAMP) REALM="$(REALM)" CLUSTER_DOMAIN="$(CLUSTER_DOMAIN)" NAMESPACE=$(NAMESPACE) DOCKER_IMAGE=$(DOCKER_IMAGE) APP=$(APP) envsubst < "$<" > "$@"
+
+# Delete the application from the cluster
+.PHONY: app-delete
+app-delete: check-logged-in-openshift check-app-not-empty FORCE
+	oc delete all,cm,sa,role,rolebinding,psp,scc,clusterrole,clusterrolebinding -l app=freeipa
+	oc delete user freeipa || true
+
+.PHONY: get-info
+get-info: check-logged-in-openshift check-app-not-empty
+	@echo ">>> oc describe pod/freeipa"
+	oc describe pod/freeipa
+	@for container in $(shell echo -n $(CONTAINERS)); do make get-info-container container=$${container}; done
+
+.PHONY: check-container-not-empty
+ifeq (,$(container))
+check-container-not-empty: FORCE
+	@[ "$(container)" != "" ] || echo "'container' must be specified: $(CONTAINERS); Try 'make container=my-container-id get-info-container'"
+	@[ "$(container)" != "" ] || exit 1
+else
+check-container-not-empty:
+endif
+
+.PHONY: check-logged-in-openshift get-info-container
+get-info-container: check-app-not-empty check-container-not-empty
+	@echo ">>> container: $(container)"
+	@if oc wait --for=condition=ready --timeout=$(AWAIT_TIMEOUT)s pod/freeipa; then oc logs freeipa -c $(container); else oc logs -f freeipa -c $(container) --insecure-skip-tls-verify-backend=true; fi

--- a/miscelanea/005-deploy-in-one-pod/README.md
+++ b/miscelanea/005-deploy-in-one-pod/README.md
@@ -1,0 +1,52 @@
+# Deploy in one Pod
+
+This proof of concept try to deploy a unique Pod with all the services
+running, but not keeping the expected security standards. This can be
+used for future scenarios which needs a deployment to review the
+configurations and how to make work scenarios with multiple clouds
+collaborating.
+
+As I have said, this is quite far from the goals we want to get, starting
+because this is no secure by default; it must be seen just as it is,
+a proof of concept, that is all.
+
+Unwished features:
+
+- Freeipa is deployed using ephimeral volume.
+- The pod is using SYS_ADMIN capability.
+- The pod is using NET_BIND capability.
+- The pod is using host paths.
+- Running systemd as root inside the container means the uid is mapped
+  to the root user in the host (critical privilege scalation security vector),
+  as it was disclosed by @ftweedal investigations
+  ([link](https://frasertweedale.github.io/blog-redhat/posts/2020-11-05-openshift-user-namespace.html)).
+
+Features:
+
+- A single pod deployment.
+- The web UI is exposed and accesible.
+- The services are accessible inside the cluster.
+
+## Quick Start
+
+Preconditions:
+
+- Review the image to be build, that it is referenced properly, and the
+  registry you have access and you are logged in.
+- Review you are loggid in the cluster and a namespace has been created.
+
+Afterward just run the below:
+
+```shell
+make container-build container-push app-deploy
+```
+
+## Notes
+
+- The certificate subject need to be different between deployments or after
+  the first redeployment we will get a `SEC_ERROR_REUSED_ISSUER_AND_SERIAL`
+  error code in Firefox; this is automated but it is something to keep in
+  mind when moving to the operator.
+- It is only exposed the web interface, more investigation is needed for the
+  intracluster scenarios, but this prototype will allow an easier way of creating
+  proof of concepts for that scenario.

--- a/miscelanea/005-deploy-in-one-pod/freeipa-admin.yaml.envsubst
+++ b/miscelanea/005-deploy-in-one-pod/freeipa-admin.yaml.envsubst
@@ -1,0 +1,161 @@
+---
+# https://docs.openshift.com/container-platform/4.5/authentication/managing-security-context-constraints.html
+# https://kubernetes-security.info/
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+  annotations:
+    kubernetes.io/description: Provides a Freeipa Pod deployed all in one
+      just for investigation prupose.
+    release.openshift.io/create-only: "true"
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  # Default capabilities anyuid
+  - "SETUID"
+  - "SETGID"
+  - "FSETID"
+  - "SETPCAP"
+  - "DAC_OVERRIDE"
+  - "NET_RAW"
+  - "NET_BIND_SERVICE"
+  - "SYS_CHROOT"
+  - "KILL"
+  - "AUDIT_WRITE"
+  - "CHOWN"
+  - "FOWNER"
+  - "SETFCAP"
+
+  # No default capabilities
+  - "SYS_ADMIN"
+  - "SYS_RESOURCE"
+  - "MKNOD"
+allowedUnsafeSysctls:
+defaultAddCapabilities:
+  # Default capabilities anyuid
+  - "CHOWN"
+  - "FOWNER"
+  - "SETFCAP"
+
+  - "SETPCAP"
+  - "SETFCAP"
+  - "SETUID"
+  - "SETGID"
+  - "DAC_OVERRIDE"
+  - "NET_BIND_SERVICE"
+  - "KILL"
+
+  # No default capabilities
+  - "SYS_ADMIN"
+  - "SYS_RESOURCE"
+  - "MKNOD"
+fsGroup:
+  type: RunAsAny
+priority: 20
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  # - system:serviceaccount:${NAMESPACE}:feeipa
+  - freeipa
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+  - hostPath
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "get", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps", "pods", "services"]
+    verbs: ["create"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes", "routes/custom-host"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+subjects:
+  - kind: ServiceAccount
+    name: freeipa
+  - kind: User
+    name: freeipa
+roleRef:
+  kind: Role
+  name: freeipa
+  apiGroup: rbac.authorization.k8s.io
+---
+# create a new ClusterRole (since SCC’s are cluster scoped instead of namespace
+# scoped) that will provide access to a given SCC
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - freeipa
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: freeipa
+subjects:
+  - kind: ServiceAccount
+    name: freeipa
+    namespace: ${NAMESPACE}

--- a/miscelanea/005-deploy-in-one-pod/freeipa.yaml.envsubst
+++ b/miscelanea/005-deploy-in-one-pod/freeipa.yaml.envsubst
@@ -1,0 +1,448 @@
+# Proof of Concept that launch ipa-server-install in an initContainer,
+# preparing the whole data volume.
+#
+# Quick Start:
+#   make app-delete app-deploy get-info
+#
+# References:
+#   https://systemd.io/CONTAINER_INTERFACE/
+#   https://stackoverflow.com/questions/52940774/kubernetes-how-to-check-current-domain-set-by-cluster-domain-from-pod
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+data:
+  DEBUG_TRACE: "2"
+  IPA_SERVER_HOSTNAME: "${APP}.apps.${CLUSTER_DOMAIN}"
+  IPA_SERVER_IP: "10.0.135.189"
+  # TODO Move PASSWORD into a Secret object
+  PASSWORD: "Secret123"
+  container: "podman"
+  container_uuid: ""
+  UID_BASE: ""
+  GID_BASE: ""
+  # yamllint disable rule:line-length
+  init-uid-gid-base.sh: |
+    #!/bin/bash
+    function yield {
+      echo "$*" >&2
+    }
+    function verbose {
+      yield "$*"
+      "$@"
+    }
+    echo "Script: $0"
+    TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
+    CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    echo "NAMESPACE=$DOLLAR{NAMESPACE}"
+    oc login --token ""  \
+             --certificate-authority="" \
+             https://kubernetes.default.svc:443
+    if [ "$DOLLAR{UID_BASE}" == "" ]; then
+      UID_BASE="$( oc get namespace/$DOLLAR{NAMESPACE} \
+                   -o 'jsonpath={.metadata.annotations.openshift\.io/sa\.scc\.uid-range}' )"
+      UID_BASE="$DOLLAR{UID_BASE%/*}"
+      oc patch configmap freeipa --patch "{\"data\":{\"UID_BASE\": \"$DOLLAR{UID_BASE}\"}}"
+    fi
+    if [ "$DOLLAR{GID_BASE}" == "" ]; then
+      GID_BASE="$( oc get namespace/$DOLLAR{NAMESPACE} \
+                   -o 'jsonpath={.metadata.annotations.openshift\.io/sa\.scc\.supplemental-groups}' )"
+      GID_BASE="$DOLLAR{GID_BASE%/*}"
+      oc patch configmap freeipa \
+         --patch "{\"data\":{\"GID_BASE\":\"$DOLLAR{GID_BASE}\"}}"
+    fi
+    UID_BASE="$( oc get cm/freeipa -o 'jsonpath={.data.UID_BASE}' )"
+    GID_BASE="$( oc get cm/freeipa -o 'jsonpath={.data.GID_BASE}' )"
+    echo "configMap.data.UID_BASE=$DOLLAR{UID_BASE}"
+    echo "configMap.data.GID_BASE=$DOLLAR{GID_BASE}"
+
+  # yamllint disable rule:line-length
+  init-container-uuid.sh: |
+    #!/bin/bash
+    function yield {
+      echo "$*" >&2
+    }
+    function verbose {
+      yield "$*"
+      "$@"
+    }
+    echo "Script: $0"
+    TOKEN="$(</var/run/secrets/kubernetes.io/serviceaccount/token)"
+    CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    echo "NAMESPACE=$DOLLAR{NAMESPACE}"
+    oc login --token "$DOLLAR{TOKEN}" \
+             --certificate-authority="$DOLLAR{CA_CERT}" \
+             https://kubernetes.default.svc:443
+    container_uuid="$( oc get configmap freeipa -o 'jsonpath={.data.container_uuid}' )"
+    if [ "$DOLLAR{container_uuid}" == "" ]; then
+      systemd-machine-id-setup
+      container_uuid="$(</etc/machine-id)"
+      oc patch configmap freeipa \
+         --patch "{\"data\":{\"container_uuid\": \"$DOLLAR{container_uuid}\"}}"
+    fi
+    echo "configMap.data.container_uuid='$( oc get configmap freeipa -o 'jsonpath={.data.container_uuid}' )'"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+  annotations:
+    openshift.io/scc: freeipa
+spec:
+  serviceAccountName: freeipa
+  # dnsConfig:
+  #   nameservers:
+  #     - 127.0.0.1
+  # hostAliases:
+  #   - ip: "127.0.0.1"
+  #     hostnames:
+  #       - ${APP}.apps.${CLUSTER_DOMAIN}
+  #       - apps.${CLUSTER_DOMAIN}
+  containers:
+    - name: main
+      # Change this to the image pushed to your container registry
+      # which is stored in your DOCKER_IMAGE env variable when building
+      # with 'make container-build container-push'
+      image: ${DOCKER_IMAGE}
+      imagePullPolicy: Always
+      # We need 'tty: true' to see the systemd traces
+      tty: true
+      securityContext:
+        privileged: false
+        capabilities:
+          drop:
+            # Default capabilities
+            - "NET_RAW"
+            - "SYS_CHROOT"
+            - "FSETID"
+
+            # No default capabilities
+            - "AUDIT_CONTROL"
+            - "AUDIT_READ"
+            - "BLOCK_SUSPEND"
+            - "DAC_READ_SEARCH"
+            - "IPC_LOCK"
+            - "IPC_OWNER"
+            - "LEASE"
+            - "LINUX_IMMUTABLE"
+            - "MAC_ADMIN"
+            - "MAC_OVERRIDE"
+            - "NET_ADMIN"
+            - "NET_BROADCAST"
+            - "SYS_BOOT"
+            - "SYS_MODULE"
+            - "SYS_NICE"
+            - "SYS_PACCT"
+            - "SYS_PTRACE"
+            - "SYS_RAWIO"
+            - "SYS_TIME"
+            - "SYS_TTY_CONFIG"
+            - "SYSLOG"
+            - "WAKE_ALARM"
+            - "SYS_RAWIO"
+
+            - "MKNOD"
+
+          add:
+            # Default capabilities
+            - "CHOWN"
+            - "FOWNER"
+            - "DAC_OVERRIDE"
+            - "SETUID"
+            - "SETGID"
+            - "KILL"
+            - "NET_BIND_SERVICE"
+
+            - "SETPCAP"
+            - "SETFCAP"
+
+            # No default capabilities
+            - "SYS_ADMIN"
+            - "SYS_RESOURCE"
+
+      command: ["/usr/sbin/init"]
+      args:
+        # - exit-on-finished
+        - no-exit
+        - ipa-server-install
+        - -U
+        # - --hostname
+        # - ${APP}.apps.${CLUSTER_DOMAIN}
+        - --realm
+        # - apps.${CLUSTER_DOMAIN}
+        - ${REALM}
+        - --ca-subject=CN=${NAMESPACE}-${TIMESTAMP}, O=${REALM}
+        - --no-ntp
+        - --no-sshd
+        - --no-ssh
+        - --verbose
+      env:
+        # - name: SYSTEMD_OPTS
+        #   value: "--show-status=true --unit=ipa-server-configure-first.service"
+        - name: KRB5_TRACE
+          value: /dev/console
+        - name: SYSTEMD_LOG_LEVEL
+          value: "debug"
+        - name: SYSTEMD_LOG_TARGET
+          value: "console"
+        - name: SYSTEMD_LOG_COLOR
+          value: "no"
+        - name: INIT_WRAPPER
+          value: "1"
+        - name: DEBUG_TRACE
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: DEBUG_TRACE
+        - name: PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: PASSWORD
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: UID_BASE
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: UID_BASE
+        - name: GID_BASE
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: GID_BASE
+        - name: IPA_SERVER_HOSTNAME
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: IPA_SERVER_HOSTNAME
+        - name: container_uuid
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: container_uuid
+        # - name: IPA_SERVER_IP
+        #   valueFrom:
+        #     fieldRef:
+        #       fieldPath: status.podIP
+
+        - name: container
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: container
+        - name: SYSTEMD_OFFLINE
+          value: "1"
+        - name: SYSTEMD_NSPAWN_API_VFS_WRITABLE
+          value: "network"
+      ports:
+        - name: http-tcp
+          protocol: TCP
+          containerPort: 80
+        - name: https-tcp
+          protocol: TCP
+          containerPort: 443
+
+      volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: systemd-tmp
+          mountPath: /tmp
+        - name: systemd-sys
+          mountPath: /sys
+          readOnly: true
+        - name: systemd-sys-fs-selinux
+          mountPath: /sys/fs/selinux
+          readOnly: true
+        - name: systemd-sys-firmware
+          mountPath: /sys/firmware
+          readOnly: true
+        - name: systemd-sys-kernel
+          mountPath: /sys/kernel
+          readOnly: true
+        - name: systemd-var-run
+          mountPath: /var/run
+        - name: systemd-var-dirsrv
+          mountPath: /var/run/dirsrv
+
+  initContainers:
+    - name: init-container-uuid
+      # docker.io/openshift/origin-cli:v4.0
+      image: openshift/origin-cli:v4.0
+      command: ["/opt/freeipa/init-container-uuid.sh"]
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: container_uuid
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: container_uuid
+      volumeMounts:
+        - name: scripts
+          mountPath: /opt/freeipa
+
+    - name: init-uid-gid-base
+      # docker.io/openshift/origin-cli:v4.0
+      image: openshift/origin-cli:v4.0
+      command: ["/opt/freeipa/init-uid-gid-base.sh"]
+      env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: UID_BASE
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: UID_BASE
+        - name: GID_BASE
+          valueFrom:
+            configMapKeyRef:
+              name: freeipa
+              key: GID_BASE
+      volumeMounts:
+        - name: scripts
+          mountPath: /opt/freeipa
+
+  volumes:
+    - name: data
+      emptyDir: {}
+    - name: scripts
+      configMap:
+        name: freeipa
+        items:
+          - key: "init-container-uuid.sh"
+            path: "init-container-uuid.sh"
+            mode: 0777
+          - key: "init-uid-gid-base.sh"
+            path: "init-uid-gid-base.sh"
+            mode: 0777
+    # https://github.com/containers/podman/issues/2996
+    #
+    # And from: https://systemd.io/CONTAINER_INTERFACE/
+    # Make sure to pre-mount /proc/, /sys/, and /sys/fs/selinux/ before
+    # invoking systemd, and mount /proc/sys/, /sys/, and /sys/fs/selinux/
+    # read-only in order to prevent the container from altering the host
+    # kernel’s configuration settings. (As a special exception, if your
+    # container has network namespaces enabled, feel free to make
+    # /proc/sys/net/ writable). systemd and various other subsystems (such
+    # as the SELinux userspace) have been modified to behave accordingly
+    # when these file systems are read-only. (It’s OK to mount /sys/ as
+    # tmpfs btw, and only mount a subset of its sub-trees from the real
+    # sysfs to hide /sys/firmware/, /sys/kernel/ and so on. If you do that,
+    # make sure to mark /sys/ read-only, as that condition is what systemd
+    # looks for, and is what is considered to be the API in this context.)
+    - name: systemd-sys
+      hostPath:
+        path: /sys
+        type: DirectoryOrCreate
+    - name: systemd-sys-fs-selinux
+      hostPath:
+        path: /sys/fs/selinux
+        type: Directory
+    - name: systemd-sys-firmware
+      hostPath:
+        path: /sys/firmware
+        type: Directory
+    - name: systemd-sys-kernel
+      hostPath:
+        path: /sys/kernel
+        type: Directory
+    - name: systemd-var-run
+      emptyDir:
+        medium: "Memory"
+    - name: systemd-var-dirsrv
+      emptyDir:
+        medium: "Memory"
+
+    # ----------------------------
+
+    - name: systemd-run-rpcbind
+      emptyDir:
+        medium: "Memory"
+
+    - name: systemd-tmp
+      emptyDir:
+        medium: "Memory"
+    - name: systemd-var-lib-journal
+      emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: freeipa
+  labels:
+    app: freeipa
+spec:
+  selector:
+    app: freeipa
+  ports:
+    - name: kerberos-tcp
+      port: 88
+      targetPort: 88
+      protocol: TCP
+    - name: kerberos-udp
+      port: 88
+      targetPort: 88
+      protocol: UDP
+
+    - name: kerberos-adm-tcp
+      port: 749
+      targetPort: 749
+      protocol: TCP
+    - name: kerberos-adm-udp
+      port: 749
+      targetPort: 749
+      protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: freeipa-web
+  labels:
+    app: freeipa
+spec:
+  selector:
+    app: freeipa
+  ports:
+    - name: http-tcp
+      port: 80
+      targetPort: http-tcp
+      protocol: TCP
+    - name: https-tcp
+      port: 443
+      targetPort: https-tcp
+      protocol: TCP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    openshift.io/host.generated: "true"
+    # https://docs.openshift.com/container-platform/4.6/networking/routes/route-configuration.html
+    haproxy.router.openshift.io/timeout: "2s"
+    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload
+  labels:
+    app: freeipa
+  name: freeipa
+spec:
+  host: ${APP}.apps.${CLUSTER_DOMAIN}
+  port:
+    targetPort: https-tcp
+  to:
+    kind: Service
+    name: freeipa-web
+    weight: 100
+  tls:
+    termination: passthrough
+  wildcardPolicy: None

--- a/miscelanea/005-deploy-in-one-pod/gssproxy.conf
+++ b/miscelanea/005-deploy-in-one-pod/gssproxy.conf
@@ -1,0 +1,3 @@
+[gssproxy]
+debug = true
+debug_level = 3

--- a/miscelanea/005-deploy-in-one-pod/init-data
+++ b/miscelanea/005-deploy-in-one-pod/init-data
@@ -1,0 +1,298 @@
+#!/bin/bash
+
+# Copyright 2015--2019 Jan Pazdziora
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Initialization of /data (bind-mounted volume) from /data-template
+# we IPA server was not yet configured.
+
+set -e
+
+# Turn on tracing of this script
+test -z "$DEBUG_TRACE" || {
+	set -x
+	if [ "${DEBUG_TRACE}" == "2" ]; then
+		export SYSTEMD_LOG_LEVEL="debug"
+		export SYSTEMD_LOG_TARGET="journal+console"
+		export SYSTEMD_LOG_COLOR="no"
+		export DEBUG=1
+	fi
+}
+
+cd /
+
+case "$1" in
+	/bin/install.sh|/bin/uninstall.sh|/bin/bash|bash)
+		exec "$@"
+	;;
+esac
+
+for i in /run/* /tmp/var/tmp/* /tmp/* ; do
+	if [ "$i" == '/run/secrets' ] ; then
+		:
+	elif [ -L "$i" -o -f "$i" ] ; then
+		rm -f "$i"
+	else
+		for j in "$i"/* ; do
+			if [ "$j" != '/tmp/var/tmp' ] ; then
+				rm -rf "$j"
+			fi
+		done
+	fi
+done
+
+/usr/local/bin/populate-volume-from-template /tmp
+
+# Workaround 1373562
+mkdir -p /run/lock
+
+DATA=/data
+DATA_TEMPLATE=/data-template
+
+mkdir -p /run/ipa /run/log $DATA/var/log/journal
+ln -s $DATA/var/log/journal /run/log/journal
+
+if [ "$1" == 'no-exit' -o -n "$DEBUG_NO_EXIT" ] ; then
+	if [ "$1" == 'no-exit' ] ; then
+		shift
+	fi
+	# Debugging:  Don't power off if IPA install/upgrade fails
+	# Create service drop-in to override `FailureAction`
+	for i in ipa-server-configure-first.service ipa-server-upgrade.service; do
+		mkdir -p /run/systemd/system/$i.d
+		echo -e "[Service]\nFailureAction=none" > /run/systemd/system/$i.d/50-no-poweroff.conf
+	done
+elif [ "$1" == 'exit-on-finished' ] ; then
+	for i in ipa-server-configure-first.service ipa-server-upgrade.service; do
+		mkdir -p /run/systemd/system/$i.d
+		# We'd like to use SuccessAction=poweroff here but it's only
+		# available in systemd 236.
+		echo -e "[Service]\nExecStartPost=/usr/bin/systemctl poweroff" > /run/systemd/system/$i.d/50-success-poweroff.conf
+	done
+	shift
+fi
+
+# Debugging:  Turn on tracing of ipa-server-configure-first script
+test -z "$DEBUG_TRACE" || touch /run/ipa/debug-trace
+
+COMMAND=
+if [ -n "$1" ] ; then
+	case "$1" in
+		ipa-server-install)
+			COMMAND="$1"
+			shift
+		;;
+		ipa-replica-install)
+			COMMAND="$1"
+			shift
+		;;
+		-*)
+			:
+		;;
+		*)
+		echo "Invocation error: command [$1] not supported." >&2
+		exit 8
+
+	esac
+fi
+if [ -z "$COMMAND" ] ; then
+	if [ -f $DATA/ipa-replica-install-options ] ; then
+		COMMAND=ipa-replica-install
+	else
+		COMMAND=ipa-server-install
+	fi
+fi
+
+if [ -n "$IPA_SERVER_INSTALL_OPTS" ] && [ "$COMMAND" != 'ipa-server-install' ] && [ "$COMMAND" != 'ipa-replica-install' ] ; then
+	echo "Invocation error: IPA_SERVER_INSTALL_OPTS should only be used with ipa-server-install or ipa-replica-install." >&2
+	exit 7
+fi
+
+OPTIONS_FILE=/run/ipa/$COMMAND-options
+
+DATA_OPTIONS_FILE=$DATA/$COMMAND-options
+touch $OPTIONS_FILE
+chmod 660 $OPTIONS_FILE
+for i in "$@" ; do
+	printf '%q\n' "$i" >> $OPTIONS_FILE
+done
+
+_HOSTNAME_IN_NEXT=false
+for i in $( cat $OPTIONS_FILE ) ; do
+	if $_HOSTNAME_IN_NEXT ; then
+		IPA_SERVER_HOSTNAME="$i"
+		break
+	fi
+        case "$i" in
+                "--hostname" | "-h")
+			_HOSTNAME_IN_NEXT=true
+                        ;;
+                --hostname=*)
+                        IPA_SERVER_HOSTNAME="${i#--hostname=}"
+                        break
+                        ;;
+	esac
+done
+
+if [ -f "$DATA/hostname" ] ; then
+	STORED_HOSTNAME="$( cat $DATA/hostname )"
+	if ! [ "$HOSTNAME" == "$STORED_HOSTNAME" ] ; then
+		# Attempt to set hostname from within container, this
+		# will pass if the container has SYS_ADMIN capability.
+		if hostname $STORED_HOSTNAME 2> /dev/null ; then
+			HOSTNAME=$( hostname )
+			if [ "$HOSTNAME" == "$STORED_HOSTNAME" ] && ! [ "$IPA_SERVER_HOSTNAME" == "$HOSTNAME" ] ; then
+				echo "Using stored hostname $STORED_HOSTNAME, ignoring $IPA_SERVER_HOSTNAME."
+			fi
+		fi
+	fi
+	IPA_SERVER_HOSTNAME=$STORED_HOSTNAME
+fi
+
+HOSTNAME_SHORT=${HOSTNAME%%.*}
+if [ "$HOSTNAME_SHORT" == "$HOSTNAME" ] ; then
+	if [ -z "$IPA_SERVER_HOSTNAME" ] ; then
+		echo "Container invoked without fully-qualified hostname" >&2
+		echo "   and without specifying hostname to use." >&2
+		echo "Consider using -h FQDN option to docker run." >&2
+		exit 15
+	fi
+	# Container is run without FQDN set, we try to "set" it in /etc/hosts
+	cp /etc/hosts /etc/hosts.dist
+	sed "s/$HOSTNAME/$IPA_SERVER_HOSTNAME $IPA_SERVER_HOSTNAME. &/" /etc/hosts.dist > /etc/hosts
+	rm -f /etc/hosts.dist
+	HOSTNAME=$IPA_SERVER_HOSTNAME
+fi
+
+if ! [ -f "$DATA/hostname" ] ; then
+	echo "$HOSTNAME" > "$DATA/hostname"
+fi
+
+function create_machine_id () {
+	# only triggers when /etc/machine-id is a symlink and not bind-mounted into
+	# the container by a container runtime.
+	if [ -L /etc/machine-id ] && [ ! -f $DATA/etc/machine-id ] ; then
+		# https://systemd.io/CONTAINER_INTERFACE/
+		# shellcheck disable=SC2154
+		if [ "${container_uuid}" != "" ]; then
+			echo "${container_uuid}" > "${DATA}/etc/machine-id"
+		else
+			dbus-uuidgen --ensure=$DATA/etc/machine-id
+		fi
+		chmod 444 $DATA/etc/machine-id
+	fi
+}
+
+if ! [ -f /etc/ipa/ca.crt ] ; then
+	if ! [ -f $DATA/ipa.csr ] ; then
+		# Do not refresh $DATA in the second stage of the external CA setup
+		/usr/local/bin/populate-volume-from-template $DATA
+		create_machine_id
+	fi
+	if [ -n "$PASSWORD" ] ; then
+		if [ "$COMMAND" == 'ipa-server-install' ] ; then
+			printf '%q\n' "--admin-password=$PASSWORD" >> $OPTIONS_FILE
+			if ! grep -sq '^--ds-password' $OPTIONS_FILE $DATA_OPTIONS_FILE ; then
+				printf '%q\n' "--ds-password=$PASSWORD" >> $OPTIONS_FILE
+			fi
+		elif [ "$COMMAND" == 'ipa-replica-install' ] ; then
+			if grep -sq '^--principal' $OPTIONS_FILE $DATA_OPTIONS_FILE ; then
+				printf '%q\n' "--admin-password=$PASSWORD" >> $OPTIONS_FILE
+			else
+				printf '%q\n' "--password=$PASSWORD" >> $OPTIONS_FILE
+			fi
+		else
+			echo "Warning: ignoring environment variable PASSWORD." >&2
+		fi
+	fi
+	if [ -n "$IPA_SERVER_INSTALL_OPTS" ] ; then
+		if [ "$COMMAND" == 'ipa-server-install' -o "$COMMAND" = 'ipa-replica-install' ] ; then
+			echo "$IPA_SERVER_INSTALL_OPTS" >> $OPTIONS_FILE
+		else
+			echo "Warning: ignoring environment variable IPA_SERVER_INSTALL_OPTS." >&2
+		fi
+	fi
+	if [ -n "$DEBUG" ] ; then
+		echo "--debug" >> $OPTIONS_FILE
+	fi
+fi
+
+# Check the volume-version of the bind-mounted volume, upgrade if it's
+# different from the one in this image.
+# The volume-upgrade file names are in format:
+#         ipa-volume-upgrade-$OLDVERSION-$NEWVERSION
+if [ -f "$DATA/volume-version" ] ; then
+	DATA_VERSION=$(cat $DATA/volume-version)
+	IMAGE_VERSION=$(cat /etc/volume-version)
+	if ! [ "$DATA_VERSION" == "$IMAGE_VERSION" ] ; then
+		if [ -x /usr/sbin/ipa-volume-upgrade-$DATA_VERSION-$IMAGE_VERSION ] ; then
+			echo "Migrating $DATA data volume version $DATA_VERSION to $IMAGE_VERSION."
+			if /usr/sbin/ipa-volume-upgrade-$DATA_VERSION-$IMAGE_VERSION ; then
+				cat /etc/volume-version > $DATA/volume-version
+			else
+				echo "Migration of $DATA volume to version $IMAGE_VERSION failed."
+				exit 13
+			fi
+		fi
+	fi
+fi
+if [ -f "$DATA/build-id" ] ; then
+	if ! cmp -s $DATA/build-id $DATA_TEMPLATE/build-id ; then
+		echo "FreeIPA server is already configured but with different version, volume update."
+		/usr/local/bin/populate-volume-from-template $DATA
+		create_machine_id
+		sha256sum -c /etc/volume-data-autoupdate 2> /dev/null | awk -F': ' '/OK$/ { print $1 }' \
+			| while read f ; do
+				rm -f "$DATA/$f"
+				if [ -e "$DATA_TEMPLATE/$f" ] ; then
+					( cd $DATA_TEMPLATE && tar cf - "./$f" ) | ( cd $DATA && tar xvf - )
+				fi
+			done
+		cat /etc/volume-data-list | while read i ; do
+			if [ -e $DATA_TEMPLATE$i ] && [ -e $DATA$i ] ; then
+				chown --reference=$DATA_TEMPLATE$i $DATA$i
+				chmod --reference=$DATA_TEMPLATE$i $DATA$i
+			fi
+		done
+		SYSTEMD_OPTS=--unit=ipa-server-upgrade.service
+	fi
+	if [ -f /etc/ipa/ca.crt ] ; then
+		rm -f "$DATA/etc/systemd/system/multi-user.target.wants/ipa-server-configure-first.service"
+	fi
+fi
+
+echo "$(date) $0 $*" >> /var/log/ipa-server-configure-first.log
+
+SHOW_LOG=${SHOW_LOG:-1}
+if [ "$SHOW_LOG" == 1 ] ; then
+	for i in /var/log/ipa-server-configure-first.log /var/log/ipa-server-run.log ; do
+		if ! [ -f $i ] ; then
+			touch $i
+		fi
+	done
+	(
+	trap '' SIGHUP
+	tail --silent -n 0 -f --retry /var/log/ipa-server-configure-first.log /var/log/ipa-server-run.log 2> /dev/null < /dev/null &
+	)
+fi
+
+if [ -n "$IPA_SERVER_IP" ] ; then
+	echo "$IPA_SERVER_IP" > /run/ipa/ipa-server-ip
+fi
+
+[ "$DEBUG_TRACE" != "" ] && env
+# exec /usr/sbin/init --show-status=false $SYSTEMD_OPTS
+exec /usr/sbin/init --show-status=true $SYSTEMD_OPTS
+
+exit 10

--- a/miscelanea/005-deploy-in-one-pod/init-wrapper.sh
+++ b/miscelanea/005-deploy-in-one-pod/init-wrapper.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+
+function dump-debug-info
+{
+    # About /etc/hostname
+    echo ">> /etc/hostname content"
+    ls -l /etc/hostname
+    cat /etc/hostname
+
+    # Display mounts
+    echo ">> Mount points"
+    cat /proc/mounts
+
+    # Display devices mounted
+    echo ">> Mounted devices"
+    find /dev
+
+    # Display environment variables
+    echo ">> Environment variables"
+    env
+}
+
+
+function run_init_wrapper
+{
+    [ "${DEBUG_TRACE}" == "2" ] && dump-debug-info
+    unset INIT_WRAPPER
+    init_extra_args="${init_extra_args} --verbose"
+    # shellcheck disable=SC2086
+    exec /usr/local/sbin/init "$@" ${init_extra_args}
+}
+
+
+function run_bash
+{
+    unset INIT_WRAPPER
+    exec /bin/bash "$@"
+}
+
+
+init_extra_args=""
+[ "${DEBUG_TRACE}" == "2" ] && {
+    [ "${INIT_WRAPPER}" == "1" ] && {
+        init_extra_args="${init_extra_args} --verbose"
+    }
+    export SYSTEMD_LOG_LEVEL="debug"
+    export SYSTEMD_LOG_TARGET="console"
+    export SYSTEMD_LOG_COLOR="no"
+}
+
+# shellcheck disable=SC2086
+[ "${INIT_WRAPPER}" == "1" ] && run_init_wrapper "$@" ${init_extra_args}
+[ "${INIT_WRAPPER}" == "2" ] && run_bash "$@"
+unset INIT_WRAPPER
+
+# shellcheck disable=SC2086
+exec /usr/sbin/original/init "$@" ${init_extra_args}

--- a/miscelanea/README.md
+++ b/miscelanea/README.md
@@ -8,3 +8,6 @@ Contents:
 - **[001-enable-container-manage-cgroup-sebool](001-enable-container-manage-cgroup-sebool/EnablingSebool.md)**:
   Provide the MachineConfig object which enable the container_manage_cgroup
   sebool.
+- **[005-deploy-in-one-pod](005-deploy-in-one-pod/README.md)**:
+  Proof of concept which deploy a Pod with Freeipa and expose the web interface.
+


### PR DESCRIPTION
Proof of concept that gather the knowledge of previous pocs and
create a set of manifests that allow to deploy one pod with
Freeipa and expose the web interface.

This deployment is not secure, and it should be used only for
development and previewing.