### PR TITLE
Integrate checkov tool into the pipeline for linting kubernete manifests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,9 +71,30 @@ jobs:
           ./devel/lint.sh  $( find . -name 'Dockerfile' \
           -o -name 'Dockerfile.*' )
 
+  lint-manifests:
+    name: Lint Kubernetes objects
+    needs: [environment]
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Lint Kustomize files
+        continue-on-error: true
+        run: |-
+          ./devel/generate-checkov-report.sh \
+          | sed 's/\x1b[[0-9;]*[a-zA-Z]//g' \
+          | tee checkov-report.txt
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: checkov-report.txt
+          path: checkov-report.txt
+
   build:
     name: Build stage
-    needs: [lint-golang, lint-extra-files]
+    needs: [lint-golang, lint-extra-files, lint-manifests]
 
     runs-on: ubuntu-20.04
 
@@ -112,7 +133,7 @@ jobs:
           GO111MODULE: "on"
           IMG_BASE: "${{ secrets.IMG_BASE }}"
           DOCKER_AUTH: "${{ secrets.DOCKER_AUTH }}"
-        run: |
+        run: |-
           export PATH=$PATH:$(go env GOPATH)/bin
           export TAG="${GITHUB_SHA}"
           export CONTAINER_IMAGE_FILE="${IMG_BASE##*/}.tar"

--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -40,3 +40,19 @@ The settings for dive tool are located at .dive-ci.yml which are the settings
 used in the pipeline. The helper script `./devel/dive.sh` use the same
 settings; the command `make dive` is calling to the helper script under the
 hood.
+
+## Checking kustomize manifests
+
+A helper script has been provided for running checkov tool for the kustomize
+manifests generated, so that the security can be analyzed.
+
+For using it, we only have to run from the repository root the below:
+
+```shell
+./devel/generate-checkov-report.sh
+```
+
+The script return 0 if nothing failed scanning the manifest security, else
+a number greater than 0 indicating how many kustomize directories failed.
+
+The report is printed out in the standard output and error.

--- a/devel/generate-checkov-report.sh
+++ b/devel/generate-checkov-report.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+##
+# Generate checkov report for the kustomize directories.
+##
+
+source "devel/include/verbose.inc"
+
+
+if command -v podman &>/dev/null; then CRI=podman
+elif command -v docker &>/dev/null; then CRI=docker
+else die "No supported container runtime was found"
+fi
+
+
+function analize-directory
+{
+    local directory="$1"
+    [ -e "${directory}" ] || die "'${directory}' directory does not exist"
+
+    echo "Scaning '${directory}' directory"
+    verbose \
+    ${CRI} run --rm -t \
+               -v "${PWD}:${PWD}" \
+               -w "${PWD}" \
+               bridgecrew/checkov \
+               -d "${directory}"
+}
+
+reto=0
+
+analize-directory "./config/crd" || reto=$(( reto + 1 ))
+analize-directory "./config/certmanager" || reto=$(( reto + 1 ))
+analize-directory "./config/default" || reto=$(( reto + 1 ))
+analize-directory "./config/manager" || reto=$(( reto + 1 ))
+analize-directory "./config/prometheus" || reto=$(( reto + 1 ))
+analize-directory "./config/rbac" || reto=$(( reto + 1 ))
+analize-directory "./config/webhook" || reto=$(( reto + 1 ))
+
+if [ "${reto}" -gt 0 ]; then yield "Found hints on ${reto} directories"
+else yield "No hints found in directories"
+fi
+
+exit ${reto}


### PR DESCRIPTION
Integrate [checkov](https://github.com/bridgecrewio/checkov) in the pipeline and append a helper script for running it.

For using the script we run the below from the repository root:

```shell
./devel/generate-checkov-report.sh
```
Checkov is a static code analysis tool for infrastructure-as-code.
