### PR TITLE
Fix 'no space left on device' while building the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
@@ -15,7 +12,9 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN go mod download \
+    && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go \
+    && rm -rf "${GOPATH}"
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
This fix the root cause that was evoking the following error in the pipeline:

```raw
STEP 9: FROM gcr.io/distroless/static:nonroot
Getting image source signatures
Copying blob sha256:9e4425256ce4503b2a009683be02372ee51d411e9cc3547919e064fee4970eab
Copying config sha256:88055b6758df5ed37dc68692e2c8ffefc165a22f544896b3277dc414ec03ea37
Writing manifest to image destination
Storing signatures
time="2021-02-14T20:23:47Z" level=error msg="error deleting build container \"df8c632a13d29af04315af8f188588977ab136998bff6dd379005b9fb0a4bd80\": identifier is not a container\n"
Error: identifier is not a container: error preparing container for next step: error creating build container: error creating container: error creating read-write layer with ID "d33634e43f97af7168ee18a546c1addaf872380761e6b48bb49d918352cb5c97": no space left on device
make: *** [Makefile:119: container-build] Error 125
Error: Process completed with exit code 2.
```

By shrinking the size of the resulting layer while building the container image.