### PR TITLE
Fix some neats in pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
           go env
           go version
 
+      - name: Available disk space
+        run: df -H
+
   lint-golang:
     name: Lint golang code
     needs: [environment]

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ manifests: controller-gen
 # Launch lint
 .PHONY: lint
 lint:
-	./devel/lint.sh
+	./devel/lint.sh *.go $(shell find controllers -name '*.go') $(shell find api -name '*.go')
 
 # Run go fmt against code
 .PHONY: fmt

--- a/devel/generate-checkov-report.sh
+++ b/devel/generate-checkov-report.sh
@@ -12,6 +12,9 @@ elif command -v docker &>/dev/null; then CRI=docker
 else die "No supported container runtime was found"
 fi
 
+TTY_OPTS=
+tty &>/dev/null && TTY_OPTS="-ti"
+
 
 function analize-directory
 {
@@ -20,22 +23,17 @@ function analize-directory
 
     echo "Scaning '${directory}' directory"
     verbose \
-    ${CRI} run --rm -t \
+    ${CRI} run --rm ${TTY_OPTS} \
                -v "${PWD}:${PWD}" \
                -w "${PWD}" \
                bridgecrew/checkov \
+               --framework kubernetes \
                -d "${directory}"
 }
 
 reto=0
 
-analize-directory "./config/crd" || reto=$(( reto + 1 ))
-analize-directory "./config/certmanager" || reto=$(( reto + 1 ))
-analize-directory "./config/default" || reto=$(( reto + 1 ))
-analize-directory "./config/manager" || reto=$(( reto + 1 ))
-analize-directory "./config/prometheus" || reto=$(( reto + 1 ))
-analize-directory "./config/rbac" || reto=$(( reto + 1 ))
-analize-directory "./config/webhook" || reto=$(( reto + 1 ))
+analize-directory "./config/" || reto=$(( reto + 1 ))
 
 if [ "${reto}" -gt 0 ]; then yield "Found hints on ${reto} directories"
 else yield "No hints found in directories"

--- a/devel/lint.sh
+++ b/devel/lint.sh
@@ -33,6 +33,10 @@ UNKNOWN_FILES=()
 
 FORCE=""
 
+TTY_OPTS=
+tty &>/dev/null && TTY_OPTS="-it"
+
+
 if command -v podman &>/dev/null; then
     oci="podman"
 elif command -v docker &>/dev/null; then
@@ -47,7 +51,8 @@ fi
 function lint-shellscript
 {
     [ $# -eq 0 ] && return 0
-    $oci run --rm -it \
+
+    $oci run --rm ${TTY_OPTS} \
              --volume "$PWD:/data:z" \
              --workdir "/data" \
              --entrypoint shellcheck \
@@ -62,7 +67,7 @@ function lint-shellscript
 function lint-dockerfile
 {
     [ $# -eq 0 ] && return 0
-    $oci run --rm -it \
+    $oci run --rm ${TTY_OPTS} \
              --volume "$PWD:/data:z" \
              --workdir "/data" \
              --entrypoint /bin/hadolint \
@@ -79,7 +84,7 @@ function lint-dockerfile
 function lint-yaml
 {
     [ $# -eq 0 ] && return 0
-    $oci   run --rm -it \
+    $oci   run --rm ${TTY_OPTS} \
                --volume "$PWD:/data:z" \
                --workdir "/data" \
                --entrypoint yamllint \
@@ -101,7 +106,7 @@ function lint-go
     reto=0
     for file in "${@}"
     do
-        $oci   run --rm -it \
+        $oci   run --rm ${TTY_OPTS} \
                    -e "GOPATH=/go" \
                    --volume "$GOPATH:/go:z" \
                    --volume "$PWD:/data:z" \
@@ -125,7 +130,7 @@ function lint-markdown
     reto=0
     for file in "$@"
     do
-        $oci   run --rm -it \
+        $oci   run --rm ${TTY_OPTS} \
                    --volume "$PWD:/data:z" \
                    --workdir "/data" \
                    docker.io/markdownlint/markdownlint \
@@ -142,7 +147,7 @@ function lint-markdown
 function lint-kubeobject
 {
     [ $# -eq 0 ] && return 0
-    $oci   run --rm -it \
+    $oci   run --rm ${TTY_OPTS} \
                --volume "$PWD:/data:z" \
                --workdir "/data" \
                --entrypoint /bin/bash \


### PR DESCRIPTION
pipeline: Fix some warning message and gather additional information for transitory failures of it.

- Add additional step for gathering information from the pipeline environment.
- Improve `make lint` rule for restrict it to golang files.
- Fix warning message in pipeline about tty when running container

signed-off: Alejandro Visiedo <avisiedo@redhat.com>