### PR TITLE
pipeline: Workaround for prow /test unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,11 @@ help:
 # Run tests
 ENVTEST_ASSETS_DIR:=$(shell pwd)/testbin
 .PHONY: test
+# idmocp-243 Workarounded by using the tool from v0.8.3 tag
 test: generate fmt vet manifests
 	mkdir -p "$(ENVTEST_ASSETS_DIR)"
 	test -f "$(ENVTEST_ASSETS_DIR)/setup-envtest.sh" \
-	|| curl -sSLo "$(ENVTEST_ASSETS_DIR)/setup-envtest.sh" https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
+	|| curl -sSLo "$(ENVTEST_ASSETS_DIR)/setup-envtest.sh" "https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh"
 	source "$(ENVTEST_ASSETS_DIR)/setup-envtest.sh"; \
 	fetch_envtest_tools "$(ENVTEST_ASSETS_DIR)"; \
 	setup_envtest_env "$(ENVTEST_ASSETS_DIR)"; \


### PR DESCRIPTION
This is a workaround for making the pipeline run again. The real
solution is to install the new setup-envtest tool base on golang
instead of this script, but it requires golang 1.16.

signed-off: Alejandro Visiedo <avisiedo@redhat.com>