### PR TITLE
config: Remove hostPath items from the configurations

### DIFF
--- a/config/rbac/scc.yaml
+++ b/config/rbac/scc.yaml
@@ -9,7 +9,7 @@ metadata:
     kubernetes.io/description: Provides a Freeipa Pod deployed all in one
       just for investigation prupose.
     release.openshift.io/create-only: "true"
-allowHostDirVolumePlugin: true
+allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
@@ -74,4 +74,3 @@ volumes:
   - persistentVolumeClaim
   - projected
   - secret
-  - hostPath

--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -81,9 +81,6 @@ func GetDataVolumeForMainPod(m *v1alpha1.IDM, defaultStorage string) corev1.Volu
 
 // MainPodForIDM return a master pod for an IDM CRD
 func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *corev1.Pod {
-	sDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
-	sDirectory := corev1.HostPathDirectory
-
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetMainPodName(m),
@@ -229,26 +226,6 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *c
 							MountPath: "/tmp",
 						},
 						{
-							Name:      "systemd-sys",
-							MountPath: "/sys",
-							ReadOnly:  true,
-						},
-						{
-							Name:      "systemd-sys-fs-selinux",
-							MountPath: "/sys/fs/selinux",
-							ReadOnly:  true,
-						},
-						{
-							Name:      "systemd-sys-firmware",
-							MountPath: "/sys/firmware",
-							ReadOnly:  true,
-						},
-						{
-							Name:      "systemd-sys-kernel",
-							MountPath: "/sys/kernel",
-							ReadOnly:  true,
-						},
-						{
 							Name:      "systemd-var-run",
 							MountPath: "/var/run",
 						},
@@ -261,42 +238,6 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *c
 			},
 			Volumes: []corev1.Volume{
 				GetDataVolumeForMainPod(m, defaultStorage),
-				{
-					Name: "systemd-sys",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/sys",
-							Type: &sDirectoryOrCreate,
-						},
-					},
-				},
-				{
-					Name: "systemd-sys-fs-selinux",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/sys/fs/selinux",
-							Type: &sDirectory,
-						},
-					},
-				},
-				{
-					Name: "systemd-sys-firmware",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/sys/firmware",
-							Type: &sDirectory,
-						},
-					},
-				},
-				{
-					Name: "systemd-sys-kernel",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/sys/kernel",
-							Type: &sDirectory,
-						},
-					},
-				},
 				{
 					Name: "systemd-var-run",
 					VolumeSource: corev1.VolumeSource{

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -22,49 +22,11 @@ func GetEphimeralVolumeForMainStatefulset(m *v1alpha1.IDM) corev1.Volume {
 // GetVolumeListForMainStatefulset Return the VolumeList for the Pod Spec embeded into
 // the Statefulset definition, giveng an IDM object.
 func GetVolumeListForMainStatefulset(m *v1alpha1.IDM) []corev1.Volume {
-	sDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
-	sDirectory := corev1.HostPathDirectory
 	var result []corev1.Volume = []corev1.Volume{}
 	if m.Spec.VolumeClaimTemplate == nil {
 		result = append(result, GetEphimeralVolumeForMainStatefulset(m))
 	}
 	result = append(result, []corev1.Volume{
-		{
-			Name: "systemd-sys",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys",
-					Type: &sDirectoryOrCreate,
-				},
-			},
-		},
-		{
-			Name: "systemd-sys-fs-selinux",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys/fs/selinux",
-					Type: &sDirectory,
-				},
-			},
-		},
-		{
-			Name: "systemd-sys-firmware",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys/firmware",
-					Type: &sDirectory,
-				},
-			},
-		},
-		{
-			Name: "systemd-sys-kernel",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/sys/kernel",
-					Type: &sDirectory,
-				},
-			},
-		},
 		{
 			Name: "systemd-var-run",
 			VolumeSource: corev1.VolumeSource{
@@ -266,26 +228,6 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage st
 								{
 									Name:      "systemd-tmp",
 									MountPath: "/tmp",
-								},
-								{
-									Name:      "systemd-sys",
-									MountPath: "/sys",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "systemd-sys-fs-selinux",
-									MountPath: "/sys/fs/selinux",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "systemd-sys-firmware",
-									MountPath: "/sys/firmware",
-									ReadOnly:  true,
-								},
-								{
-									Name:      "systemd-sys-kernel",
-									MountPath: "/sys/kernel",
-									ReadOnly:  true,
 								},
 								{
 									Name:      "systemd-var-run",

--- a/manifests/statefulset_test.go
+++ b/manifests/statefulset_test.go
@@ -258,26 +258,6 @@ var _ = Describe("LOCAL:Statefulset tests", func() {
 								MountPath: "/tmp",
 							},
 							{
-								Name:      "systemd-sys",
-								MountPath: "/sys",
-								ReadOnly:  true,
-							},
-							{
-								Name:      "systemd-sys-fs-selinux",
-								MountPath: "/sys/fs/selinux",
-								ReadOnly:  true,
-							},
-							{
-								Name:      "systemd-sys-firmware",
-								MountPath: "/sys/firmware",
-								ReadOnly:  true,
-							},
-							{
-								Name:      "systemd-sys-kernel",
-								MountPath: "/sys/kernel",
-								ReadOnly:  true,
-							},
-							{
 								Name:      "systemd-var-run",
 								MountPath: "/var/run",
 							},
@@ -299,8 +279,6 @@ var _ = Describe("LOCAL:Statefulset tests", func() {
 				It("has the volumeList expected", func(done Done) {
 					go func() {
 						defer GinkgoRecover()
-						sDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
-						sDirectory := corev1.HostPathDirectory
 
 						volumeList := []corev1.Volume{
 							// Statefulset object add this automatically to the Pod, but
@@ -309,42 +287,6 @@ var _ = Describe("LOCAL:Statefulset tests", func() {
 							// When the PVC template section is defined, this function
 							// return an empty entry
 							// manifests.GetEphimeralVolumeForMainStatefulset(&idm),
-							{
-								Name: "systemd-sys",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/sys",
-										Type: &sDirectoryOrCreate,
-									},
-								},
-							},
-							{
-								Name: "systemd-sys-fs-selinux",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/sys/fs/selinux",
-										Type: &sDirectory,
-									},
-								},
-							},
-							{
-								Name: "systemd-sys-firmware",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/sys/firmware",
-										Type: &sDirectory,
-									},
-								},
-							},
-							{
-								Name: "systemd-sys-kernel",
-								VolumeSource: corev1.VolumeSource{
-									HostPath: &corev1.HostPathVolumeSource{
-										Path: "/sys/kernel",
-										Type: &sDirectory,
-									},
-								},
-							},
 							{
 								Name: "systemd-var-run",
 								VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
- Remove from single-pod manifest.
- Remove from statefulset manifest.
- Update unit tests.
- Remove hostPath from SCC object.

> Rebase this when PR #35 is merged
    
Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>
