### PR TITLE
golang: Update to go1.16 version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+        id: go
 
       - name: Gather environment information
         env:
@@ -45,6 +49,10 @@ jobs:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+        id: go
 
       - name: Lint go files
         run: |
@@ -62,6 +70,10 @@ jobs:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idsteps
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+        id: go
 
       - name: Lint Shell Script files
         run: ./devel/lint.sh  $( find . -name '*.sh' )
@@ -82,6 +94,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+        id: go
 
       - name: Lint Kustomize files
         continue-on-error: true
@@ -103,11 +119,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Go
-        uses: actions/setup-go@master
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: '1.16'
         id: go
 
       - name: Clean docker infrastructure

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Experimental freeipa-operator for Freeipa.
 
 ## Quick Start
 
+> It requires golang 1.16; if your system is providing a lower
+> version, consider to install [gvm](https://github.com/moovweb/gvm#installing).
+> for using different golang versions.
+
 1. Clone the repository by:
 
    ```shell

--- a/devel/install-local-tools.sh
+++ b/devel/install-local-tools.sh
@@ -169,6 +169,7 @@ function install-packages
     esac
 } # install-packages
 
+# FIXME Clean-up this function
 ##
 # Install kustomize tool from source code. The other ways failed in Fedora 32.
 # See: https://kubernetes-sigs.github.io/kustomize/installation/source/#install-the-kustomize-cli-from-local-source-with-cloning-the-repo
@@ -230,6 +231,11 @@ function install-dive-tool
 ##
 function install-go-tools
 {
+    local GODOC_VERSION="v0.1.6"
+    local DELVE_VERSION="v1.7.1"
+    local GOLINT_VERSION="master"
+    local KUSTOMIZE_VERSION="v3.2.3"
+
     [ "$GOPATH" == "" ] && {
         GOPATH="$HOME/go"
         [ -e "$GOPATH" ] || mkdir -p "$GOPATH"
@@ -237,17 +243,16 @@ function install-go-tools
     }
 
     # Install godoc
-    (cd && GO111MODULE=on verbose go get -u -v golang.org/x/tools/cmd/godoc) || die "Installing godoc"
+    go install golang.org/x/tools/cmd/godoc@${GODOC_VERSION} || die "Installing godoc"
 
     # Install debugger
-    (cd && GO111MODULE=on verbose go get -u -v github.com/go-delve/delve/cmd/dlv) || die "Installing dlv"
+    go install github.com/go-delve/delve/cmd/dlv@${DELVE_VERSION} || die "Installing dlv"
 
     # Install linter
-    (cd && GO111MODULE=on verbose go get -u -v golang.org/x/lint/golint) || die "Installing golint"
+    go install golang.org/x/lint/golint@${GOLINT_VERSION} || die "Installing golint"
 
     # Install kustomize
-    # install-kustomize-from-source || die "Installing kustomize"
-    (cd && GO111MODULE=on verbose go get -v sigs.k8s.io/kustomize/kustomize/v3@v3.2.3) || die "Installing kustomize"
+    go install sigs.k8s.io/kustomize/kustomize/v3@${KUSTOMIZE_VERSION} || die "Installing kustomize"
 
     # Install dive
     install-dive-tool

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // https://blog.golang.org/using-go-modules
 module github.com/freeipa/freeipa-operator
 
-go 1.14
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.4.0


### PR DESCRIPTION
- Once changed pipeline, Dockerfile, go.mod files, the
  script ./devel/install-local-tools.sh could use the
  go install command and the situation when installing
  delve debugger was fixed.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>