### PR TITLE
Deploy kind does not work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ CONFIG ?= default
 # GO111MODULE="on" go get sigs.k8s.io/kind@v0.10.0
 KIND_VERSION := v0.11.1
 KIND_CLUSTER_NAME ?= idmcontroller
-K8S_NODE_IMAGE ?= v1.19.0
+K8S_NODE_IMAGE ?= v1.21.1
 PROMETHEUS_INSTANCE_NAME ?= prometheus-operator
 # CONFIG_MAP_NAME ?= initcontainer-configmap
 

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ container-build: check-container-runtime
 
 .PHONY: container-build-root
 container-build-root: container-build container-save
-	cat $(CONTAINER_IMAGE_FILE) | sudo $(DOCKER) load $(IMG)
+	cat $(CONTAINER_IMAGE_FILE) | sudo $(DOCKER) load
 
 .PHONY: container-delete-root
 container-delete-root:
@@ -215,12 +215,12 @@ $(CONTAINER_IMAGE_FILE).gz: FORCE
 .PHONY: container-load
 container-load: check-container-runtime
 	@if [ ! -e "$(CONTAINER_IMAGE_FILE)" ]; then echo "No image file found. Run 'make container-build container-save' to generate a fresh image file before load it"; exit 2; fi
-	cat $(CONTAINER_IMAGE_FILE) | $(DOCKER) load $(IMG)
+	cat $(CONTAINER_IMAGE_FILE) | $(DOCKER) load
 
 .PHONY: container-load-gz
 container-load-gz: check-container-runtime
 	@if [ ! -e "$(CONTAINER_IMAGE_FILE).gz" ]; then echo "No image file found. Run 'make container-build container-save-gz' to generate a fresh image file before load it"; exit 2; fi
-	gunzip $(CONTAINER_IMAGE_FILE).gz -c | $(DOCKER) load $(IMG)
+	gunzip $(CONTAINER_IMAGE_FILE).gz -c | $(DOCKER) load
 
 # Push the docker image
 .PHONY: container-push

--- a/Makefile
+++ b/Makefile
@@ -307,11 +307,11 @@ endif
 ifeq (podman,$(DOCKER))
 kind-load-img: container-build-root
 	@echo "Loading image into kind"
-	sudo -E --preserve-env=HOME,PATH,GOPATH -- $(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME) --loglevel "trace"
+	sudo -E --preserve-env=HOME,PATH,GOPATH -- $(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME) --verbosity 9
 else ifeq (docker,$(DOCKER))
 kind-load-img: container-build
 	@echo "Loading image into kind"
-	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME) --loglevel "trace"
+	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME) --verbosity 9
 else
 kind-load-img: container-build-root
 	@echo container enginer not supported; exit 1

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ kind-create: kind
 	then \
 	  echo "Cluster '$(KIND_CLUSTER_NAME)' already exists"; \
 	else \
-	  $(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image=kindest/node:$(K8S_NODE_IMAGE); \
+	  $(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image=kindest/node:$(K8S_NODE_IMAGE) --config config/kind/config.yaml; \
 	fi
 else ifeq (docker,$(DOCKER))
 kind-create:
@@ -267,7 +267,7 @@ kind-create:
 	then \
 	  echo "Cluster '$(KIND_CLUSTER_NAME)' already exists"; \
 	else \
-	  $(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image=kindest/node:$(K8S_NODE_IMAGE); \
+	  $(KIND) create cluster --name $(KIND_CLUSTER_NAME) --image=kindest/node:$(K8S_NODE_IMAGE) --config config/kind/config.yaml; \
 	fi
 else
 kind-create:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ CONFIG ?= default
 
 # Install kind by:
 # GO111MODULE="on" go get sigs.k8s.io/kind@v0.10.0
+KIND_VERSION := v0.11.1
 KIND_CLUSTER_NAME ?= idmcontroller
 K8S_NODE_IMAGE ?= v1.19.0
 PROMETHEUS_INSTANCE_NAME ?= prometheus-operator
@@ -252,7 +253,7 @@ deploy-kind: kind-create kind-load-img deploy-cluster
 .PHONY: kind
 kind:
 ifeq (, $(shell which kind))
-	@(cd && GO111MODULE="on" go get sigs.k8s.io/kind@v0.10.0)
+	@(cd && GO111MODULE="on" go get sigs.k8s.io/kind@$(KIND_VERSION))
 KIND=$(GOBIN)/kind
 else
 KIND=$(shell which kind)

--- a/config/kind/config.yaml
+++ b/config/kind/config.yaml
@@ -1,0 +1,19 @@
+# https://kind.sigs.k8s.io/docs/user/configuration/
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# featureGates: []
+# runtimeConfig: []
+networking:
+  ipFamily: dual
+nodes:
+  - role: control-plane
+    image: "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"   # yamllint disable-line rule:line-length
+    # yamllint disable rule:line-length
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            enable-admission-plugins: NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+    # yamllint enable rule:line-length


### PR DESCRIPTION
kind-create: Fix and improvements
- Fix podman load command (thanks @vashirov ).
- Update kind version.
- Use rootless podman.
- Remove sudo commands.
- Create configuration file for it.

> Not found the way to inject the openshift controller in kind for using SecurityContextConstraints and Route objects.

Signed-off-by: Alejandro Visiedo <avisiedo@redhat.com>