### PR TITLE
Add support to customize the container image workload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -a
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+ENV WORKLOAD_IMAGE=quay.io/freeipa/freeipa-openshift-container:freeipa-server
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/HELP
+++ b/HELP
@@ -59,3 +59,6 @@ Variables:
                    ** setenforce Permissive
                    **
                    ** FINALLY: CONFIG=default-hostpath make deploy-cluster
+  WORKLOAD_IMAGE   Set the image to be used for the workload.
+                   By default "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
+                   is used.

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ KIND_CLUSTER_NAME ?= idmcontroller
 K8S_NODE_IMAGE ?= v1.19.0
 PROMETHEUS_INSTANCE_NAME ?= prometheus-operator
 # CONFIG_MAP_NAME ?= initcontainer-configmap
+WORKLOAD_IMAGE ?= "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/idm_controller.go
+++ b/controllers/idm_controller.go
@@ -41,10 +41,11 @@ import (
 type IDMReconciler struct {
 	client.Client
 
-	Log        logr.Logger
-	Scheme     *runtime.Scheme
-	BaseDomain string
-	Arguments  *arguments.Arguments
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	BaseDomain    string
+	Arguments     *arguments.Arguments
+	WorkloadImage string
 }
 
 var (
@@ -374,7 +375,7 @@ func (r *IDMReconciler) CreateMainPod(ctx context.Context, item *v1alpha1.IDM) e
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("Creating Master Pod")
-			manifest := manifests.MainPodForIDM(item, r.BaseDomain, defaultStorage)
+			manifest := manifests.MainPodForIDM(item, r.BaseDomain, r.WorkloadImage, defaultStorage)
 			ctrl.SetControllerReference(item, manifest, r.Scheme)
 			if err = r.Create(ctx, manifest); err != nil {
 				return err

--- a/controllers/idm_controller_test.go
+++ b/controllers/idm_controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("LOCAL:IDMReconciller", func() {
 				},
 			}
 			Expect(idm).ShouldNot(BeNil())
-			pod := manifests.MainPodForIDM(idm, "localhost", "ephemeral")
+			pod := manifests.MainPodForIDM(idm, "localhost", "quay.io/freeipa/freeipa-openshift-container:freeipa-server", "ephemeral")
 			It("return nil error and valid Pod Object", func() {
 				Expect(pod).ShouldNot(BeNil())
 			})

--- a/main.go
+++ b/main.go
@@ -51,9 +51,17 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
+func getWorkloadImage() string {
+	if workload, exist := os.LookupEnv("WORKLOAD_IMAGE"); exist {
+		return workload
+	}
+	return "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
+}
+
 func main() {
 	var err error
 	var ctrlArguments *arguments.Arguments
+	var workloadImage string = getWorkloadImage()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -77,9 +85,10 @@ func main() {
 	}
 
 	if err = (&controllers.IDMReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("IDM"),
-		Scheme: mgr.GetScheme(),
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controllers").WithName("IDM"),
+		Scheme:        mgr.GetScheme(),
+		WorkloadImage: workloadImage,
 	}).SetupWithManager(mgr, ctrlArguments); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IDM")
 		os.Exit(3)

--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -80,7 +80,7 @@ func GetDataVolumeForMainPod(m *v1alpha1.IDM, defaultStorage string) corev1.Volu
 }
 
 // MainPodForIDM return a master pod for an IDM CRD
-func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *corev1.Pod {
+func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultStorage string) *corev1.Pod {
 	sDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
 	sDirectory := corev1.HostPathDirectory
 
@@ -102,7 +102,7 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *c
 			Containers: []corev1.Container{
 				{
 					Name:  "main",
-					Image: "quay.io/freeipa/freeipa-openshift-container:freeipa-server",
+					Image: workload,
 					TTY:   true,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: pointy.Bool(false),


### PR DESCRIPTION
- Add WORKLOAD_IMAGE environment variable to customize the container image workload.
- The operator customize the workload based on the value of this variable; if unset or empty, then the default container image used for the workload will be `quay.io/freeipa/freeipa-openshift-container:freeipa-server`.

Example:

```shell
WORKLOAD_IMAGE="quay.io/avisied0/freeipa-openshift-container:dev-f47400e" make run
```

> This is a Red Hat marketplace requirement: https://redhat-connect.gitbook.io/certified-operator-guide/troubleshooting-and-resources/offline-enabled-operators#golang-operators 