### PR TITLE
Add support to customize the container image workload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -a
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-ENV WORKLOAD_IMAGE=quay.io/freeipa/freeipa-openshift-container:freeipa-server
+ENV RELATED_IMAGE_FREEIPA=quay.io/freeipa/freeipa-openshift-container:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -a
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+ENV WORKLOAD_IMAGE=quay.io/freeipa/freeipa-openshift-container:freeipa-server
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot

--- a/HELP
+++ b/HELP
@@ -55,6 +55,7 @@ Variables:
                    ** PASSWORD=Secret123 SAMPLE=ephemeral-storage make recreate-sample-idm
   CONFIG           The configuration to be used; by default 'default' is used, but
                    you can override setting it to 'default-hostpath'.
-  WORKLOAD_IMAGE   Set the image to be used for the workload.
+  RELATED_IMAGE_FREEIPA
+                   Set the image to be used for the workload.
                    By default "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
                    is used.

--- a/HELP
+++ b/HELP
@@ -55,3 +55,14 @@ Variables:
                    ** PASSWORD=Secret123 SAMPLE=ephemeral-storage make recreate-sample-idm
   CONFIG           The configuration to be used; by default 'default' is used, but
                    you can override setting it to 'default-hostpath'.
+
+                   ** ONLY FOR SINGLE NODE CLUSTERS AND FOR DEVELOPING **
+                   ** ACTUALLY IT NEEDS TO SET SELINUX IN PERMISSIVE MODE **
+                   **   oc debug nodes/....
+                   **   chroot /host
+                   **   setenforce Permissive
+                   **
+                   ** FINALLY: CONFIG=default-hostpath make deploy-cluster
+  WORKLOAD_IMAGE   Set the image to be used for the workload.
+                   By default "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
+                   is used.

--- a/HELP
+++ b/HELP
@@ -55,14 +55,6 @@ Variables:
                    ** PASSWORD=Secret123 SAMPLE=ephemeral-storage make recreate-sample-idm
   CONFIG           The configuration to be used; by default 'default' is used, but
                    you can override setting it to 'default-hostpath'.
-
-                   ** ONLY FOR SINGLE NODE CLUSTERS AND FOR DEVELOPING **
-                   ** ACTUALLY IT NEEDS TO SET SELINUX IN PERMISSIVE MODE **
-                   **   oc debug nodes/....
-                   **   chroot /host
-                   **   setenforce Permissive
-                   **
-                   ** FINALLY: CONFIG=default-hostpath make deploy-cluster
   WORKLOAD_IMAGE   Set the image to be used for the workload.
                    By default "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
                    is used.

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ KIND_CLUSTER_NAME ?= idmcontroller
 K8S_NODE_IMAGE ?= v1.19.0
 PROMETHEUS_INSTANCE_NAME ?= prometheus-operator
 # CONFIG_MAP_NAME ?= initcontainer-configmap
-WORKLOAD_IMAGE ?= "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
+RELATED_IMAGE_FREEIPA ?= "quay.io/freeipa/freeipa-openshift-container:latest"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ KIND_CLUSTER_NAME ?= idmcontroller
 K8S_NODE_IMAGE ?= v1.19.0
 PROMETHEUS_INSTANCE_NAME ?= prometheus-operator
 # CONFIG_MAP_NAME ?= initcontainer-configmap
+WORKLOAD_IMAGE ?= "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/idm_controller.go
+++ b/controllers/idm_controller.go
@@ -414,7 +414,7 @@ func (r *IDMReconciler) CreateStatefulsetMain(ctx context.Context, item *v1alpha
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("Creating Main Statefulset")
-			manifest := manifests.MainStatefulsetForIDM(item, r.BaseDomain, defaultStorage)
+			manifest := manifests.MainStatefulsetForIDM(item, r.BaseDomain, r.WorkloadImage, defaultStorage)
 			ctrl.SetControllerReference(item, manifest, r.Scheme)
 			if err = r.Create(ctx, manifest); err != nil {
 				return err

--- a/controllers/idm_controller.go
+++ b/controllers/idm_controller.go
@@ -42,10 +42,11 @@ import (
 type IDMReconciler struct {
 	client.Client
 
-	Log        logr.Logger
-	Scheme     *runtime.Scheme
-	BaseDomain string
-	Arguments  *arguments.Arguments
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	BaseDomain    string
+	Arguments     *arguments.Arguments
+	WorkloadImage string
 }
 
 var (
@@ -372,7 +373,7 @@ func (r *IDMReconciler) CreateMainPod(ctx context.Context, item *v1alpha1.IDM) e
 	if err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("Creating Master Pod")
-			manifest := manifests.MainPodForIDM(item, r.BaseDomain, defaultStorage)
+			manifest := manifests.MainPodForIDM(item, r.BaseDomain, r.WorkloadImage, defaultStorage)
 			ctrl.SetControllerReference(item, manifest, r.Scheme)
 			if err = r.Create(ctx, manifest); err != nil {
 				return err

--- a/controllers/idm_controller_test.go
+++ b/controllers/idm_controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("LOCAL:IDMReconciller", func() {
 				},
 			}
 			Expect(idm).ShouldNot(BeNil())
-			pod := manifests.MainPodForIDM(idm, "localhost", "ephemeral")
+			pod := manifests.MainPodForIDM(idm, "localhost", "quay.io/freeipa/freeipa-openshift-container:freeipa-server", "ephemeral")
 			It("return nil error and valid Pod Object", func() {
 				Expect(pod).ShouldNot(BeNil())
 			})

--- a/controllers/idm_controller_test.go
+++ b/controllers/idm_controller_test.go
@@ -94,9 +94,9 @@ var _ = Describe("LOCAL:IDMReconciller", func() {
 				},
 			}
 			Expect(idm).ShouldNot(BeNil())
-			pod := manifests.MainPodForIDM(idm, "localhost", "quay.io/freeipa/freeipa-openshift-container:freeipa-server", "ephemeral")
-			It("return nil error and valid Pod Object", func() {
-				Expect(pod).ShouldNot(BeNil())
+			statefulset := manifests.MainStatefulsetForIDM(idm, "localhost", "quay.io/freeipa/freeipa-openshift-container:latest", "ephemeral")
+			It("return a valid statefulset Object", func() {
+				Expect(statefulset).ShouldNot(BeNil())
 			})
 		})
 	})

--- a/main.go
+++ b/main.go
@@ -62,17 +62,18 @@ func getWatchNamespace() (string, error) {
 	return ns, nil
 }
 
-func getWorkloadImage() string {
-	if workload, exist := os.LookupEnv("WORKLOAD_IMAGE"); exist {
-		return workload
+// getWorkloadImage return t
+func getWorkloadImage() (string, error) {
+	if workload, exist := os.LookupEnv("RELATED_IMAGE_FREEIPA"); exist && workload != "" {
+		return workload, nil
 	}
-	return "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
+	return "", fmt.Errorf("RELATED_IMAGE_FREEIPA environment variable must be specified and not empty")
 }
 
 func main() {
 	var err error
 	var ctrlArguments *arguments.Arguments
-	var workloadImage string = getWorkloadImage()
+	var workloadImage string
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -81,6 +82,13 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "invalid controller arguments")
 		os.Exit(1)
+	}
+
+	// Get RELATED_IMAGE_FREEIPA
+	workloadImage, err = getWorkloadImage()
+	if err != nil {
+		setupLog.Error(err, "Reading RELATED_IMAGE_FREEIPA")
+		os.Exit(2)
 	}
 
 	// Get WATCH_NAMESPACE value

--- a/main.go
+++ b/main.go
@@ -62,9 +62,17 @@ func getWatchNamespace() (string, error) {
 	return ns, nil
 }
 
+func getWorkloadImage() string {
+	if workload, exist := os.LookupEnv("WORKLOAD_IMAGE"); exist {
+		return workload
+	}
+	return "quay.io/freeipa/freeipa-openshift-container:freeipa-server"
+}
+
 func main() {
 	var err error
 	var ctrlArguments *arguments.Arguments
+	var workloadImage string = getWorkloadImage()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
@@ -96,9 +104,10 @@ func main() {
 	}
 
 	if err = (&controllers.IDMReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("IDM"),
-		Scheme: mgr.GetScheme(),
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controllers").WithName("IDM"),
+		Scheme:        mgr.GetScheme(),
+		WorkloadImage: workloadImage,
 	}).SetupWithManager(mgr, ctrlArguments); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "IDM")
 		os.Exit(3)

--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -23,29 +23,14 @@ func buildEnvFrom(m *v1alpha1.IDM) []corev1.EnvFromSource {
 	return result
 }
 
-func NeedsPersistentVolumeClaim(m *v1alpha1.IDM) bool {
+func needsPersistentVolumeClaim(m *v1alpha1.IDM) bool {
 	return m.Spec.VolumeClaimTemplate != nil
 }
 
-func HasValidVolumeInformation(m *v1alpha1.IDM, defaultStorage string) bool {
-	if NeedsPersistentVolumeClaim(m) {
-		return true
-	}
-
-	if defaultStorage == "ephemeral" {
-		return true
-	}
-
-	if defaultStorage == "hostpath" {
-		return true
-	}
-
-	return false
-}
-
-// GetDataVolumeForPod
+// GetDataVolumeForMainPod Return a corev1.Volume block for the PVC to be mounted
+// Return a corev1.Volume structure properly filled.
 func GetDataVolumeForMainPod(m *v1alpha1.IDM, defaultStorage string) corev1.Volume {
-	if NeedsPersistentVolumeClaim(m) {
+	if needsPersistentVolumeClaim(m) {
 		return corev1.Volume{
 			Name: "data",
 			VolumeSource: corev1.VolumeSource{
@@ -160,6 +145,10 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 						"--no-ntp",
 						"--no-sshd",
 						"--no-ssh",
+						// TODO Add --verbose if some indicator for debugging
+						//      is set up such as '--verbose-freeipa' to avoid
+						//      enable it isolated from '-debug' flag which is
+						//      passed to the controller.
 					},
 					EnvFrom: buildEnvFrom(m),
 					Env: []corev1.EnvVar{

--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -149,7 +149,7 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 							},
 						},
 					},
-					Command: []string{"/usr/sbin/init"},
+					Command: []string{"/usr/local/sbin/init"},
 					Args: []string{
 						"no-exit",
 						"ipa-server-install",
@@ -160,30 +160,9 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 						"--no-ntp",
 						"--no-sshd",
 						"--no-ssh",
-						"--verbose",
 					},
 					EnvFrom: buildEnvFrom(m),
 					Env: []corev1.EnvVar{
-						{
-							Name:  "KRB5_TRACE",
-							Value: "/dev/console",
-						},
-						{
-							Name:  "SYSTEMD_LOG_LEVEL",
-							Value: "debug",
-						},
-						{
-							Name:  "SYSTEMD_LOG_COLOR",
-							Value: "no",
-						},
-						{
-							Name:  "INIT_WRAPPER",
-							Value: "1",
-						},
-						{
-							Name:  "DEBUG_TRACE",
-							Value: "2",
-						},
 						{
 							Name:  "NAMESPACE",
 							Value: m.Namespace,

--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -80,7 +80,10 @@ func GetDataVolumeForMainPod(m *v1alpha1.IDM, defaultStorage string) corev1.Volu
 }
 
 // MainPodForIDM return a master pod for an IDM CRD
-func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *corev1.Pod {
+func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultStorage string) *corev1.Pod {
+	sDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
+	sDirectory := corev1.HostPathDirectory
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetMainPodName(m),
@@ -99,7 +102,7 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *c
 			Containers: []corev1.Container{
 				{
 					Name:      "main",
-					Image:     "quay.io/freeipa/freeipa-openshift-container:freeipa-server",
+					Image:     workload,
 					TTY:       true,
 					Resources: m.Spec.Resources,
 					SecurityContext: &corev1.SecurityContext{

--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -81,9 +81,6 @@ func GetDataVolumeForMainPod(m *v1alpha1.IDM, defaultStorage string) corev1.Volu
 
 // MainPodForIDM return a master pod for an IDM CRD
 func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultStorage string) *corev1.Pod {
-	sDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
-	sDirectory := corev1.HostPathDirectory
-
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetMainPodName(m),

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -64,7 +64,7 @@ func GetVolumeListForMainStatefulset(m *v1alpha1.IDM) []corev1.Volume {
 }
 
 // MainStatefulsetForIDM return a master pod for an IDM CRD
-func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage string) *appsv1.StatefulSet {
+func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultStorage string) *appsv1.StatefulSet {
 
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -102,7 +102,7 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage st
 					Containers: []corev1.Container{
 						{
 							Name:      "main",
-							Image:     "quay.io/freeipa/freeipa-openshift-container:freeipa-server",
+							Image:     workload,
 							TTY:       true,
 							Resources: m.Spec.Resources,
 							SecurityContext: &corev1.SecurityContext{
@@ -152,7 +152,7 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage st
 									},
 								},
 							},
-							Command: []string{"/usr/sbin/init"},
+							Command: []string{"/usr/local/sbin/init"},
 							Args: []string{
 								"no-exit",
 								"ipa-server-install",
@@ -163,30 +163,9 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, defaultStorage st
 								"--no-ntp",
 								"--no-sshd",
 								"--no-ssh",
-								"--verbose",
 							},
 							EnvFrom: buildEnvFrom(m),
 							Env: []corev1.EnvVar{
-								{
-									Name:  "KRB5_TRACE",
-									Value: "/dev/console",
-								},
-								{
-									Name:  "SYSTEMD_LOG_LEVEL",
-									Value: "debug",
-								},
-								{
-									Name:  "SYSTEMD_LOG_COLOR",
-									Value: "no",
-								},
-								{
-									Name:  "INIT_WRAPPER",
-									Value: "1",
-								},
-								{
-									Name:  "DEBUG_TRACE",
-									Value: "2",
-								},
 								{
 									Name:  "NAMESPACE",
 									Value: m.Namespace,

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -163,6 +163,10 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, 
 								"--no-ntp",
 								"--no-sshd",
 								"--no-ssh",
+								// TODO Add --verbose if some indicator for debugging
+								//      is set up such as '--verbose-freeipa' to avoid
+								//      enable it isolated from '-debug' flag which is
+								//      passed to the controller.
 							},
 							EnvFrom: buildEnvFrom(m),
 							Env: []corev1.EnvVar{


### PR DESCRIPTION
- Add WORKLOAD_IMAGE environment variable to customize the container image workload.
- The operator customize the workload based on the value of this variable; if unset or empty, then the default container image used for the workload will be `quay.io/freeipa/freeipa-openshift-container:freeipa-server`.

Example:

```shell
WORKLOAD_IMAGE="quay.io/avisied0/freeipa-openshift-container:dev-f47400e" make run
```

> This is a Red Hat marketplace requirement: https://redhat-connect.gitbook.io/certified-operator-guide/troubleshooting-and-resources/offline-enabled-operators#golang-operators 