### PR TITLE
Fix dirsrv restart when pod is restarted

### DIFF
--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -202,6 +202,11 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 							Name:      "systemd-var-dirsrv",
 							MountPath: "/var/run/dirsrv",
 						},
+						// This fix 'Error - Problem accessing the lockfile /var/lock/dirsrv/slapd-*/lock'
+						{
+							Name:      "dirsrv-var-lock-dirsrv",
+							MountPath: "/var/lock/dirsrv",
+						},
 					},
 				},
 			},
@@ -233,6 +238,14 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 				},
 				{
 					Name: "systemd-tmp",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMedium("Memory"),
+						},
+					},
+				},
+				{
+					Name: "dirsrv-var-lock-dirsrv",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							Medium: corev1.StorageMedium("Memory"),

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -59,6 +59,14 @@ func GetVolumeListForMainStatefulset(m *v1alpha1.IDM) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: "dirsrv-var-lock-dirsrv",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMedium("Memory"),
+				},
+			},
+		},
 	}...)
 	return result
 }
@@ -220,6 +228,11 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, 
 								{
 									Name:      "systemd-var-dirsrv",
 									MountPath: "/var/run/dirsrv",
+								},
+								// This fix 'Error - Problem accessing the lockfile /var/lock/dirsrv/slapd-*/lock'
+								{
+									Name:      "dirsrv-var-lock-dirsrv",
+									MountPath: "/var/lock/dirsrv",
 								},
 							},
 						},

--- a/manifests/statefulset_test.go
+++ b/manifests/statefulset_test.go
@@ -289,6 +289,10 @@ var _ = Describe("LOCAL:Statefulset tests", func() {
 								Name:      "systemd-var-dirsrv",
 								MountPath: "/var/run/dirsrv",
 							},
+							{
+								Name:      "dirsrv-var-lock-dirsrv",
+								MountPath: "/var/lock/dirsrv",
+							},
 						}
 						By("Checking VolumeMounts length")
 						Expect(len(result.Spec.Template.Spec.Containers[0].VolumeMounts)).Should(Equal(len(volumeMountList)))
@@ -337,6 +341,14 @@ var _ = Describe("LOCAL:Statefulset tests", func() {
 							},
 							{
 								Name: "systemd-tmp",
+								VolumeSource: corev1.VolumeSource{
+									EmptyDir: &corev1.EmptyDirVolumeSource{
+										Medium: corev1.StorageMedium("Memory"),
+									},
+								},
+							},
+							{
+								Name: "dirsrv-var-lock-dirsrv",
 								VolumeSource: corev1.VolumeSource{
 									EmptyDir: &corev1.EmptyDirVolumeSource{
 										Medium: corev1.StorageMedium("Memory"),


### PR DESCRIPTION
Fix the error message at dirsrv log:
```raw
Error - Problem accessing the lockfile /var/lock/dirsrv/slapd-.../lock
```

By mounting '/var/lock/dirsrv' as tmpfs.