### PR TITLE
Add lifecycle container handlers

### DIFF
--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -187,6 +187,15 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 							Value: "network",
 						},
 					},
+					// https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+					// https://www.freedesktop.org/software/systemd/man/systemd.html#SIGRTMIN+3
+					Lifecycle: &corev1.Lifecycle{
+						PreStop: &corev1.Handler{
+							Exec: &corev1.ExecAction{
+								Command: ExecStopSystemd,
+							},
+						},
+					},
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http-tcp",

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -19,7 +19,7 @@ func GetEphimeralVolumeForMainStatefulset(m *v1alpha1.IDM) corev1.Volume {
 	}
 }
 
-var ExecStopSystemd []string = []string{"kill", "-s", "SIGRTMIN+3", "1"}
+var ExecStopSystemd []string = []string{"kill", "-RTMIN+3", "1"}
 
 // GetVolumeListForMainStatefulset Return the VolumeList for the Pod Spec embeded into
 // the Statefulset definition, giveng an IDM object.

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -19,6 +19,8 @@ func GetEphimeralVolumeForMainStatefulset(m *v1alpha1.IDM) corev1.Volume {
 	}
 }
 
+var ExecStopSystemd []string = []string{"kill", "-s", "SIGRTMIN+3", "1"}
+
 // GetVolumeListForMainStatefulset Return the VolumeList for the Pod Spec embeded into
 // the Statefulset definition, giveng an IDM object.
 func GetVolumeListForMainStatefulset(m *v1alpha1.IDM) []corev1.Volume {
@@ -203,6 +205,15 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, 
 								{
 									Name:  "SYSTEMD_NSPAWN_API_VFS_WRITABLE",
 									Value: "network",
+								},
+							},
+							// https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+							// https://www.freedesktop.org/software/systemd/man/systemd.html#SIGRTMIN+3
+							Lifecycle: &corev1.Lifecycle{
+								PreStop: &corev1.Handler{
+									Exec: &corev1.ExecAction{
+										Command: ExecStopSystemd,
+									},
 								},
 							},
 							Ports: []corev1.ContainerPort{

--- a/manifests/statefulset_test.go
+++ b/manifests/statefulset_test.go
@@ -259,6 +259,18 @@ var _ = Describe("LOCAL:Statefulset tests", func() {
 						ContainerPort: 443,
 					},
 				}
+				It("has container lifecycle", func(done Done) {
+					go func() {
+						defer GinkgoRecover()
+						Expect(result.Spec.Template.Spec.Containers[0].Lifecycle).ShouldNot(BeNil())
+						Expect(result.Spec.Template.Spec.Containers[0].Lifecycle.PreStop).ShouldNot(BeNil())
+						Expect(result.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec).ShouldNot(BeNil())
+						Expect(result.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command).Should(Equal(
+							manifests.ExecStopSystemd,
+						))
+						close(done)
+					}()
+				})
 				Expect(len(result.Spec.Template.Spec.Containers[0].Ports)).Should(Equal(len(portList)))
 				for index, item := range result.Spec.Template.Spec.Containers[0].Ports {
 					By("Checking result.Spec.Template.Spec.Containers[0].Ports[].Name: " + item.Name)


### PR DESCRIPTION
This change make systemd stop gracefully into the container workload.

- Add hook for preStop in Statefullset object.
- Add hook for PreStop in Pod object.
- Add unit tests for Statefullset object.