### PR TITLE
Remove file included that does not exist here

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 resources:
   - scc.yaml
-  - serviceaccount.yaml
   - role.yaml
   - role_binding.yaml
   - leader_election_role.yaml


### PR DESCRIPTION
### Description

The kustomization.yaml file at config/rbac include the file serviceaccount.yaml that is not used and it is not needed in this state. Remove the resource at config/rbac/kustomization.yaml to avoid errors when invoking kustomize build command.

### Steps

1. `kustomize build config/rbac`

### Expected result

All the resources build for config/rbac

### Current result

An error is arisen because the 'config/rbac/serviceaccount.yaml' file does not exist.

```raw
Error: accumulating resources: accumulation err='accumulating resources from 'serviceaccount.yaml': evalsymlink failure on '/home/avisiedo/idmocp/freeipa-operator/config/rbac/serviceaccount.yaml' : lstat /home/avisiedo/idmocp/freeipa-operator/config/rbac/serviceaccount.yaml: no such file or directory': evalsymlink failure on '/home/avisiedo/idmocp/freeipa-operator/config/rbac/serviceaccount.yaml' : lstat /home/avisiedo/idmocp/freeipa-operator/config/rbac/serviceaccount.yaml: no such file or directory
```

