### PR TITLE
Use ingress domain

### DIFF
--- a/config/rbac/dnses_clusterrole.yaml
+++ b/config/rbac/dnses_clusterrole.yaml
@@ -6,11 +6,18 @@ metadata:
   name: dnses-role
 rules:
   # Allow to retrieve the baseDomain
-  - apiGroups:
-      - "config.openshift.io"
+  - apiGroups: ["config.openshift.io"]
     resources:
-      - "dnses"
+      - dnses
     verbs:
       - list
       - get
       - watch
+
+  - apiGroups: ["config.openshift.io"]
+    resources:
+      - ingresses
+    verbs:
+      - watch
+      - list
+      - get

--- a/config/rbac/dnses_clusterrole.yaml
+++ b/config/rbac/dnses_clusterrole.yaml
@@ -5,15 +5,7 @@ metadata:
   creationTimestamp: null
   name: dnses-role
 rules:
-  # Allow to retrieve the baseDomain
-  - apiGroups: ["config.openshift.io"]
-    resources:
-      - dnses
-    verbs:
-      - list
-      - get
-      - watch
-
+  # Allow to retrieve the ingress domain
   - apiGroups: ["config.openshift.io"]
     resources:
       - ingresses

--- a/controllers/idm_controller.go
+++ b/controllers/idm_controller.go
@@ -77,7 +77,7 @@ func (r *IDMReconciler) ReadIngressDomainFromOpenshiftConfig(ctx context.Context
 	return ingressConfig.Spec.Domain, nil
 }
 
-// InitBaseDomain Initialize the cache for the IngressDomain that is
+// InitIngressDomain Initialize the cache for the IngressDomain that is
 // used by the cluster.
 // ctx The memory context to be used for the operation.
 // Return nil if it was initialized, else an error object.

--- a/manifests/route.go
+++ b/manifests/route.go
@@ -8,10 +8,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+// GenerateDefaultRoute Given a namespace and ingressDomain
+// it generate the default hostname value for the route.
+// Return a string
+func GenerateDefaultRoute(namespace string, ingressDomain string) string {
+	return namespace + "." + ingressDomain
+}
+
 // RouteForIDM Create the Route manifest for this IDM resource
-// clusterDomain It is the subdomain associated to the cluster
-//
-func RouteForIDM(m *v1alpha1.IDM, clusterDomain string) *routev1.Route {
+// ingressDomain It is the ingress domain associated to the cluster
+// Return a configure Route object
+func RouteForIDM(m *v1alpha1.IDM, host string) *routev1.Route {
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
@@ -25,7 +32,7 @@ func RouteForIDM(m *v1alpha1.IDM, clusterDomain string) *routev1.Route {
 			Labels: LabelsForIDM(m),
 		},
 		Spec: routev1.RouteSpec{
-			Host: m.Namespace + ".apps." + clusterDomain,
+			Host: host,
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.IntOrString{
 					Type:   intstr.String,

--- a/manifests/single_pod.go
+++ b/manifests/single_pod.go
@@ -65,7 +65,7 @@ func GetDataVolumeForMainPod(m *v1alpha1.IDM, defaultStorage string) corev1.Volu
 }
 
 // MainPodForIDM return a master pod for an IDM CRD
-func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultStorage string) *corev1.Pod {
+func MainPodForIDM(m *v1alpha1.IDM, ingressDomain string, workload string, defaultStorage string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetMainPodName(m),
@@ -154,8 +154,8 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 						"ipa-server-install",
 						"-U",
 						"--realm",
-						GetRealm(m, baseDomain),
-						"--ca-subject=" + GetCaSubject(m, baseDomain),
+						GetRealm(m, ingressDomain),
+						"--ca-subject=" + GetCaSubject(m, ingressDomain),
 						"--no-ntp",
 						"--no-sshd",
 						"--no-ssh",
@@ -172,7 +172,7 @@ func MainPodForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultS
 						},
 						{
 							Name:  "IPA_SERVER_HOSTNAME",
-							Value: GetIpaServerHostname(m, baseDomain),
+							Value: GetIpaServerHostname(m, ingressDomain),
 						},
 						{
 							Name:  "container_uuid",

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -178,8 +178,13 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, 
 								"ipa-server-install",
 								"-U",
 								"--realm",
+<<<<<<< HEAD
 								m.Spec.Realm,
 								"--ca-subject=" + GetCaSubject(m, baseDomain),
+=======
+								GetRealm(m, ingressDomain),
+								"--ca-subject=" + GetCaSubject(m, ingressDomain),
+>>>>>>> 2e1bfab (Use ingress domain instead of cluster basedomain)
 								"--no-ntp",
 								"--no-sshd",
 								"--no-ssh",
@@ -196,7 +201,7 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, 
 								},
 								{
 									Name:  "IPA_SERVER_HOSTNAME",
-									Value: GetIpaServerHostname(m, baseDomain),
+									Value: GetIpaServerHostname(m, ingressDomain),
 								},
 								{
 									Name:  "container_uuid",

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -67,9 +67,9 @@ func GetVolumeListForMainStatefulset(m *v1alpha1.IDM) []corev1.Volume {
 }
 
 // MainStatefulsetForIDM return a master pod for an IDM CRD
-func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultStorage string) *appsv1.StatefulSet {
+func MainStatefulsetForIDM(m *v1alpha1.IDM, ingressDomain string, workload string, defaultStorage string) *appsv1.StatefulSet {
 	if m.Spec.Realm == "" {
-		m.Spec.Realm = GetRealm(m, baseDomain)
+		m.Spec.Realm = GetRealm(m, ingressDomain)
 	}
 
 	statefulset := &appsv1.StatefulSet{
@@ -178,13 +178,8 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, 
 								"ipa-server-install",
 								"-U",
 								"--realm",
-<<<<<<< HEAD
-								m.Spec.Realm,
-								"--ca-subject=" + GetCaSubject(m, baseDomain),
-=======
 								GetRealm(m, ingressDomain),
 								"--ca-subject=" + GetCaSubject(m, ingressDomain),
->>>>>>> 2e1bfab (Use ingress domain instead of cluster basedomain)
 								"--no-ntp",
 								"--no-sshd",
 								"--no-ssh",

--- a/manifests/utils.go
+++ b/manifests/utils.go
@@ -46,19 +46,19 @@ func RandStringBytes(n int) string {
 }
 
 // GetRealm Get the REALM for the POD
-func GetRealm(m *v1alpha1.IDM, baseDomain string) string {
-	return "APPS." + strings.ToUpper(baseDomain)
+func GetRealm(m *v1alpha1.IDM, ingressDomain string) string {
+	return strings.ToUpper(ingressDomain)
 }
 
 // GetIpaServerHostname Get the hostname passed to ipa installation
-func GetIpaServerHostname(m *v1alpha1.IDM, baseDomain string) string {
-	return m.Namespace + ".apps." + baseDomain
+func GetIpaServerHostname(m *v1alpha1.IDM, ingressDomain string) string {
+	return m.Namespace + "." + ingressDomain
 }
 
 // GetCaSubject Get the CA Subject for the POD
-func GetCaSubject(m *v1alpha1.IDM, baseDomain string) string {
+func GetCaSubject(m *v1alpha1.IDM, ingressDomain string) string {
 	cn := m.Namespace + "-" + RandStringBytes(7)
-	o := GetRealm(m, baseDomain)
+	o := GetRealm(m, ingressDomain)
 	return "CN=" + cn + ", O=" + o
 }
 


### PR DESCRIPTION
As an Administrator I want the operator use the ingress domain that meet with:

- The StatefulSet and Route objects will use this to set the configuration more accurate.
- A new function based on the command:

```sh
oc get ingresses.config/cluster -o jsonpath={.spec.domain}
```
