### PR TITLE
Realm field is ignored

### DIFF
--- a/config/samples/ephemeral-storage/idm_v1alpha1_freeipa.yaml
+++ b/config/samples/ephemeral-storage/idm_v1alpha1_freeipa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
+  # Update this value for your cluster ingress
   realm: APPS-CRC.TESTING
   passwordSecret: idm-sample
   resources:

--- a/config/samples/ephemeral-storage/idm_v1alpha1_freeipa.yaml
+++ b/config/samples/ephemeral-storage/idm_v1alpha1_freeipa.yaml
@@ -5,12 +5,12 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
-  realm: bar
+  realm: APPS-CRC.TESTING
   passwordSecret: idm-sample
   resources:
     requests:
-      cpu: "1500m"
-      memory: "2Gi"
-    limits:
       cpu: "2000m"
-      memory: "2Gi"
+      memory: "3Gi"
+    limits:
+      cpu: "3000m"
+      memory: "4Gi"

--- a/config/samples/hostpath-storage/idm_v1alpha1_freeipa.yaml
+++ b/config/samples/hostpath-storage/idm_v1alpha1_freeipa.yaml
@@ -5,15 +5,15 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
-  realm: bar
+  realm: APPS-CRC.TESTING
   passwordSecret: idm-sample
   resources:
     requests:
-      cpu: "1500m"
-      memory: "2Gi"
-    limits:
       cpu: "2000m"
-      memory: "2Gi"
+      memory: "3Gi"
+    limits:
+      cpu: "3000m"
+      memory: "4Gi"
   volumeClaimTemplate:
     accessModes:
       - ReadWriteOnce

--- a/config/samples/hostpath-storage/idm_v1alpha1_freeipa.yaml
+++ b/config/samples/hostpath-storage/idm_v1alpha1_freeipa.yaml
@@ -5,6 +5,7 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
+  # Update this value for your cluster ingress
   realm: APPS-CRC.TESTING
   passwordSecret: idm-sample
   resources:

--- a/config/samples/idm_v1alpha1_freeipa_nosecret.yaml
+++ b/config/samples/idm_v1alpha1_freeipa_nosecret.yaml
@@ -5,6 +5,7 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
+  # Update this value for your cluster ingress
   realm: APPS-CRC.TESTING
   resources:
     requests:

--- a/config/samples/idm_v1alpha1_freeipa_nosecret.yaml
+++ b/config/samples/idm_v1alpha1_freeipa_nosecret.yaml
@@ -5,11 +5,11 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
-  realm: bar
+  realm: APPS-CRC.TESTING
   resources:
     requests:
-      cpu: "1500m"
-      memory: "2Gi"
-    limits:
       cpu: "2000m"
-      memory: "2Gi"
+      memory: "3Gi"
+    limits:
+      cpu: "4000m"
+      memory: "3Gi"

--- a/config/samples/persistent-storage/idm_v1alpha1_freeipa.yaml
+++ b/config/samples/persistent-storage/idm_v1alpha1_freeipa.yaml
@@ -5,15 +5,15 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
-  realm: bar
+  realm: APPS-CRC.TESTING
   passwordSecret: idm-sample
   resources:
     requests:
-      cpu: "1500m"
-      memory: "2Gi"
-    limits:
       cpu: "2000m"
-      memory: "2Gi"
+      memory: "3Gi"
+    limits:
+      cpu: "3000m"
+      memory: "4Gi"
   volumeClaimTemplate:
     resources:
       requests:

--- a/config/samples/with-secret/idm_v1alpha1_freeipa.yaml
+++ b/config/samples/with-secret/idm_v1alpha1_freeipa.yaml
@@ -5,5 +5,5 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
-  realm: bar
+  realm: APPS-CRC.TESTING
   passwordSecret: "$(IDM_SECRET)"

--- a/config/samples/with-secret/idm_v1alpha1_freeipa.yaml
+++ b/config/samples/with-secret/idm_v1alpha1_freeipa.yaml
@@ -5,5 +5,6 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
+  # Update this value for your cluster ingress
   realm: APPS-CRC.TESTING
   passwordSecret: "$(IDM_SECRET)"

--- a/config/samples/without-secret/idm_v1alpha1_freeipa_nosecret.yaml
+++ b/config/samples/without-secret/idm_v1alpha1_freeipa_nosecret.yaml
@@ -5,5 +5,5 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
-  realm: bar
+  realm: APPS-CRC.TESTING
   passwordSecret: "$(SECRET_PASSWORD)"

--- a/config/samples/without-secret/idm_v1alpha1_freeipa_nosecret.yaml
+++ b/config/samples/without-secret/idm_v1alpha1_freeipa_nosecret.yaml
@@ -5,5 +5,6 @@ metadata:
   name: idm-sample
 spec:
   # Add fields here
+  # Update this value for your cluster ingress
   realm: APPS-CRC.TESTING
   passwordSecret: "$(SECRET_PASSWORD)"

--- a/manifests/statefulset.go
+++ b/manifests/statefulset.go
@@ -19,6 +19,7 @@ func GetEphimeralVolumeForMainStatefulset(m *v1alpha1.IDM) corev1.Volume {
 	}
 }
 
+// ExecStopSystemd Command that stop systemd
 var ExecStopSystemd []string = []string{"kill", "-RTMIN+3", "1"}
 
 // GetVolumeListForMainStatefulset Return the VolumeList for the Pod Spec embeded into
@@ -67,6 +68,9 @@ func GetVolumeListForMainStatefulset(m *v1alpha1.IDM) []corev1.Volume {
 
 // MainStatefulsetForIDM return a master pod for an IDM CRD
 func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, defaultStorage string) *appsv1.StatefulSet {
+	if m.Spec.Realm == "" {
+		m.Spec.Realm = GetRealm(m, baseDomain)
+	}
 
 	statefulset := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -174,7 +178,7 @@ func MainStatefulsetForIDM(m *v1alpha1.IDM, baseDomain string, workload string, 
 								"ipa-server-install",
 								"-U",
 								"--realm",
-								GetRealm(m, baseDomain),
+								m.Spec.Realm,
 								"--ca-subject=" + GetCaSubject(m, baseDomain),
 								"--no-ntp",
 								"--no-sshd",


### PR DESCRIPTION
### Description

The Realm field from the custom resource is being ignored.

### Steps

Running the controller in a cluster, create an idm custom resource.

### Expected behavior

The realm used into the workload is the one specified into the custom resource.

### Current behavior

The field value is ignored and it is using a realm based into the cluster baseDomain.