### PR TITLE
Fix: Running the "make cert-manager-self-signed-issuer-create" in step 7 fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ Experimental freeipa-operator for Freeipa.
 
 **Steps**:
 
+1. Create the Security Context Constraint profile (if not yet):
+
+   ```sh
+   oc create -f config/rbac/scc.yaml
+   ```
+
 1. Create a namespace:
 
    ```sh
@@ -216,7 +222,13 @@ Experimental freeipa-operator for Freeipa.
 1. Remove the namespace:
 
    ```sh
-   oc delete namespace ipa
+   oc delete project ipa
+   ```
+
+1. Remove the Security Context Constraint profile by:
+
+   ```sh
+   oc delete -f config/rbac/scc.yaml
    ```
 
 ----

--- a/README.md
+++ b/README.md
@@ -87,28 +87,32 @@ Experimental freeipa-operator for Freeipa.
    Setup complete
 
    Next steps:
-   	1. You must make sure these network ports are open:
-   		TCP Ports:
-   		  * 80, 443: HTTP/HTTPS
-   		  * 389, 636: LDAP/LDAPS
-   		  * 88, 464: kerberos
-   		UDP Ports:
-   		  * 88, 464: kerberos
+      1. You must make sure these network ports are open:
+         TCP Ports:
+           * 80, 443: HTTP/HTTPS
+           * 389, 636: LDAP/LDAPS
+           * 88, 464: kerberos
+         UDP Ports:
+           * 88, 464: kerberos
 
-   	2. You can now obtain a kerberos ticket using the command: 'kinit admin'
-   	   This ticket will allow you to use the IPA tools (e.g., ipa user-add)
-   	   and the web user interface.
-   	3. Kerberos requires time synchronization between clients
-   	   and servers for correct operation. You should consider enabling chronyd.
+      2. You can now obtain a kerberos ticket using the command: 'kinit admin'
+         This ticket will allow you to use the IPA tools (e.g., ipa user-add)
+         and the web user interface.
+      3. Kerberos requires time synchronization between clients
+         and servers for correct operation. You should consider enabling chronyd.
 
    Be sure to back up the CA certificates stored in /root/cacert.p12
    These files are required to create replicas. The password for these
    files is the Directory Manager password
    The ipa-server-install command was successful
    FreeIPA server does not run DNS server, skipping update-self-ip-address.
-   Created symlink /etc/systemd/system/container-ipa.target.wants/ipa-server-update-self-ip-address.service → /usr/lib/systemd/system/ipa-server-update-self-ip-address.service.
-   Created symlink /etc/systemd/system/container-ipa.target.wants/ipa-server-upgrade.service → /usr/lib/systemd/system/ipa-server-upgrade.service.
-   Removed /etc/systemd/system/container-ipa.target.wants/ipa-server-configure-first.service.
+   Created symlink /etc/systemd/system/container-ipa.target.wants/ipa-server-
+   update-self-ip-address.service → /usr/lib/systemd/system/ipa-server-update-
+   self-ip-address.service.
+   Created symlink /etc/systemd/system/container-ipa.target.wants/ipa-server-
+   upgrade.service → /usr/lib/systemd/system/ipa-server-upgrade.service.
+   Removed /etc/systemd/system/container-ipa.target.wants/ipa-server-configure-
+   first.service.
    [  OK  ] Finished Configure IPA server upon the first start.
    FreeIPA server configured.
    ```

--- a/README.md
+++ b/README.md
@@ -56,22 +56,68 @@ Experimental freeipa-operator for Freeipa.
    # When the cert-manager operator is installed, run this:
    make cert-manager-self-signed-issuer-create
 
+   # Create the scc object
+   oc create -f config/rbac/scc.yaml
+
    # Finally deploy the operator in the cluster with:
    make deploy
    ```
 
+1. Create `private.mk` file and update IMG_BASE variable value.
+
+   ```sh
+   cp -vf private.mk.example private.mk
+   ```
+
+   > Update `private.mk` where required
+
 1. And create a new idm resource by:
 
    ```sh
-   cat > private.mk <<EOF
-   IDM_ADMIN_PASSWORD=myPassword124
-   IDM_DM_PASSWORD=DMmyPassword124
-   SAMPLE=config/samples/ephemeral-storage
-   EOF
    make sample-create
    ```
 
-   > You can check more samples at `config/samples` directory.
+   > The deployment spend about 5 minutes to finish, after that
+   > you will see something like the below when running:
+   > `oc logs --tail=35 pod/idm-sample-main-0`
+
+   ```raw
+   [  OK  ] Finished Identity, Policy, Audit.
+   ==============================================================================
+   Setup complete
+
+   Next steps:
+   	1. You must make sure these network ports are open:
+   		TCP Ports:
+   		  * 80, 443: HTTP/HTTPS
+   		  * 389, 636: LDAP/LDAPS
+   		  * 88, 464: kerberos
+   		UDP Ports:
+   		  * 88, 464: kerberos
+
+   	2. You can now obtain a kerberos ticket using the command: 'kinit admin'
+   	   This ticket will allow you to use the IPA tools (e.g., ipa user-add)
+   	   and the web user interface.
+   	3. Kerberos requires time synchronization between clients
+   	   and servers for correct operation. You should consider enabling chronyd.
+
+   Be sure to back up the CA certificates stored in /root/cacert.p12
+   These files are required to create replicas. The password for these
+   files is the Directory Manager password
+   The ipa-server-install command was successful
+   FreeIPA server does not run DNS server, skipping update-self-ip-address.
+   Created symlink /etc/systemd/system/container-ipa.target.wants/ipa-server-update-self-ip-address.service → /usr/lib/systemd/system/ipa-server-update-self-ip-address.service.
+   Created symlink /etc/systemd/system/container-ipa.target.wants/ipa-server-upgrade.service → /usr/lib/systemd/system/ipa-server-upgrade.service.
+   Removed /etc/systemd/system/container-ipa.target.wants/ipa-server-configure-first.service.
+   [  OK  ] Finished Configure IPA server upon the first start.
+   FreeIPA server configured.
+   ```
+
+1. Now you should be able to reach out the web interface by:
+
+   ```sh
+   xdg-open "https://$(oc get route idm-sample -o jsonpath='{.spec.host}')"
+   ```
 
 1. Look at your objects by: `kubectl get all,idm,pvc,secrets`
 
@@ -79,6 +125,7 @@ Experimental freeipa-operator for Freeipa.
 
    ```sh
    make undeploy
+   oc delete -f config/rbac/scc.yaml
    ```
 
 ## Executing tests
@@ -107,7 +154,6 @@ Experimental freeipa-operator for Freeipa.
 **Pre-requisites**:
 
 - A proper `private.mk` file setup. (see `private.mk.example`).
-- A namespace selected (eg. `oc new-project ipa`).
 - The freeipa SecurityContextConstraint created (`oc create -f config/rbac/scc.yaml`).
 
 **Steps**:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Experimental freeipa-operator for Freeipa.
 
 1. Now create a new namespace by: `oc create namespace my-freeipa`
 
-1. As clust-admin user logged in the cluster run:
+1. As cluster-admin user logged in the cluster run:
 
    ```sh
    make install

--- a/README.md
+++ b/README.md
@@ -31,10 +31,20 @@ Experimental freeipa-operator for Freeipa.
 
    ```sh
    make test
-   operator-sdk scorecard bundle
+   ./bin/operator-sdk scorecard bundle
    ```
 
-1. Now create a new namespace by: `kubectl create namespace my-freeipa`
+1. Now create a new namespace by: `oc create namespace my-freeipa`
+
+1. As clust-admin user logged in the cluster run:
+
+   ```sh
+   make install
+   ```
+
+   > This will generate the CRD and install it into the cluster.
+   > The CRD need to be installed into the cluster even if we
+   > run the controller from our local workstation.
 
 1. Run locally outside the cluster by (webhooks are disabled):
 
@@ -45,7 +55,7 @@ Experimental freeipa-operator for Freeipa.
 1. Or run inside the cluster by (first build and push the image):
 
    ```sh
-   kubectl login https://my-cluster:6443
+   oc login https://my-cluster:6443
    export IMAGE_TAG_BASE=quay.io/USER_ORG/freeipa-operator
    podman login quay.io
    make docker-build

--- a/config/certmanager/subscription.yaml
+++ b/config/certmanager/subscription.yaml
@@ -15,4 +15,4 @@ spec:
   sourceNamespace: openshift-marketplace
   channel: stable
   installPlanApproval: Automatic
-  startingCSV: cert-manager.v1.6.1
+  startingCSV: cert-manager.v1.7.2

--- a/mk/cert-manager.mk
+++ b/mk/cert-manager.mk
@@ -10,3 +10,10 @@ cert-manager-install:  ## Install cert-manager operator
 cert-manager-uninstall:  ## Delete cert-manager operator
 	kubectl delete -f config/certmanager/subscription.yaml --wait=true
 
+.PHONY: cert-manager-self-signed-issuer-create
+cert-manager-self-signed-issuer-create:  ## Create a cluster self signed issuer
+	kubectl create -f config/certmanager/clusterissuer-selfsigned.yaml
+
+.PHONY: cert-manager-self-signed-issuer-delete
+cert-manager-self-signed-issuer-delete:  ## Delete the cluster self signed issuer
+	kubectl delete -f config/certmanager/clusterissuer-selfsigned.yaml

--- a/mk/cert-manager.mk
+++ b/mk/cert-manager.mk
@@ -3,17 +3,17 @@
 
 .PHONY: cert-manager-install
 cert-manager-install:  ## Install cert-manager operator
-	kubectl create -f config/certmanager/subscription.yaml
-	kubectl wait Subscription/cert-manager -n openshift-operators --for=condition=CatalogSourcesUnhealthy=False
+	oc create -f config/certmanager/subscription.yaml
+	oc wait Subscription/cert-manager -n openshift-operators --for=condition=CatalogSourcesUnhealthy=False
 
 .PHONY: cert-manager-uninstall
 cert-manager-uninstall:  ## Delete cert-manager operator
-	kubectl delete -f config/certmanager/subscription.yaml --wait=true
+	oc delete -f config/certmanager/subscription.yaml --wait=true
 
 .PHONY: cert-manager-self-signed-issuer-create
 cert-manager-self-signed-issuer-create:  ## Create a cluster self signed issuer
-	kubectl create -f config/certmanager/clusterissuer-selfsigned.yaml
+	oc create -f config/certmanager/clusterissuer-selfsigned.yaml
 
 .PHONY: cert-manager-self-signed-issuer-delete
 cert-manager-self-signed-issuer-delete:  ## Delete the cluster self signed issuer
-	kubectl delete -f config/certmanager/clusterissuer-selfsigned.yaml
+	oc delete -f config/certmanager/clusterissuer-selfsigned.yaml

--- a/mk/samples.mk
+++ b/mk/samples.mk
@@ -12,13 +12,13 @@ sample-create: check-password-is-provided  ## Create the IDM sample resource
 	 || kubectl create secret generic idm-sample \
 	          --from-literal=IPA_ADMIN_PASSWORD='$(IPA_ADMIN_PASSWORD)' \
 	          --from-literal=IPA_DM_PASSWORD='$(IPA_DM_PASSWORD)'
-	$(KUSTOMIZE) build $(SAMPLE) | kubectl create -f -
+	oc create -f $(SAMPLE)
 
 .PHONY: sample-delete
 sample-delete:  ## Delete the IDM sample resource
-	@kubectl get secret/idm-sample &>/dev/null \
+	@!kubectl get secret/idm-sample &>/dev/null \
 	 || kubectl delete secrets/idm-sample
-	-$(KUSTOMIZE) build $(SAMPLE) | kubectl delete --wait=true -f -
+	oc delete -f $(SAMPLE)
 
 .PHONY: sample-recreate
 .NOTPARALLEL: sample-recreate

--- a/mk/samples.mk
+++ b/mk/samples.mk
@@ -8,16 +8,16 @@ sample-build:
 
 .PHONY: sample-create
 sample-create: check-password-is-provided  ## Create the IDM sample resource
-	@kubectl get secret/idm-sample &>/dev/null \
-	 || kubectl create secret generic idm-sample \
+	@oc get secret/idm-sample &>/dev/null \
+	 || oc create secret generic idm-sample \
 	          --from-literal=IPA_ADMIN_PASSWORD='$(IPA_ADMIN_PASSWORD)' \
 	          --from-literal=IPA_DM_PASSWORD='$(IPA_DM_PASSWORD)'
 	oc create -f $(SAMPLE)
 
 .PHONY: sample-delete
 sample-delete:  ## Delete the IDM sample resource
-	@!kubectl get secret/idm-sample &>/dev/null \
-	 || kubectl delete secrets/idm-sample
+	@!oc get secret/idm-sample &>/dev/null \
+	 || oc delete secrets/idm-sample
 	oc delete -f $(SAMPLE)
 
 .PHONY: sample-recreate

--- a/private.mk.example
+++ b/private.mk.example
@@ -1,0 +1,44 @@
+# The operator is using semantic version, so try to use a proper
+# version for your local builds and to create the proper versioned
+# artifacts
+VERSION ?= 0.0.1-$(shell git rev-list --count HEAD ^master)
+
+# First time you need to create and make public the repositories
+# or after push the images for the first time, go to your
+# container image registry repository and make it public
+# TODO Update IMG_BASE
+$(error Update IMG_BASE with your user account and remove this line)
+IMG_BASE ?= quay.io/YOUR_USER
+IMAGE_TAG_BASE ?= $(IMG_BASE)/freeipa-operator
+
+# Channels to be used in BUNDLE_CHANNELS
+CHANNELS := alpha
+export CHANNELS
+DEFAULT_CHANNEL := alpha
+export DEFAULT_CHANNEL
+
+# This variable specify the image that is related with the
+# workload that is deployed by the controller when running
+# the controller from the workstation.
+# If you want to use a different image, be sure to set this
+# value pointing to the workload you want to use
+RELATED_IMAGE_FREEIPA ?= quay.io/freeipa/freeipa-openshift-container:latest
+export RELATED_IMAGE_FREEIPA
+
+# This is used by the 'make sample-create' and 'make sample-delete' rules
+SAMPLE ?= ./config/samples/persistent-storage.yaml
+
+# When running the controller locally, this indicate the
+# namespace to watch for idm resources when setting up the controller
+WATCH_NAMESPACE ?= $(shell oc project -q)
+export WATCH_NAMESPACE
+
+# This disable the webhooks when we are running the controller locally.
+# It is useful for debugging the controller from the local workstation.
+ENABLE_WEBHOOKS := false
+export ENABLE_WEBHOOKS
+
+# The admin and directory manager passwords that will be used to create
+# the secret. This is used when running the samples by 'make sample-create'
+IPA_ADMIN_PASSWORD ?= Secret124
+IPA_DM_PASSWORD ?= DMSecret124


### PR DESCRIPTION
- Add removed rules to mk/cert-manager.mk to create/delete self-signed certificate issuer.
- Update samples-* rules to use a single file.
- Add 'private.mk.example' to quickly create 'private.mk' file.
- Update 'Quickstart' and 'Deploying with OLM' sections.

Fix issue: https://github.com/freeipa/freeipa-operator/issues/54 